### PR TITLE
chore: AIクラスタ Stage3 進捗リンク更新

### DIFF
--- a/project-management/content-improvement.md
+++ b/project-management/content-improvement.md
@@ -7,9 +7,9 @@
 | 書籍 | Stage2（構成レビュー） | Stage3（表現・スタイル） | 参照 |
 | --- | --- | --- | --- |
 | ai-era-engineers-mind-book | 完了（https://github.com/itdojp/ai-era-engineers-mind-book/pull/61） | 完了（https://github.com/itdojp/ai-era-engineers-mind-book/pull/62） | レビュー文書: `docs/project-management/structure-review-round1.md` |
-| ai-testing-strategy-book | 完了（https://github.com/itdojp/ai-testing-strategy-book/pull/66） | 進行中（直近: https://github.com/itdojp/ai-testing-strategy-book/pull/71） | レビュー文書: `docs/project-management/structure-review-round1.md` |
+| ai-testing-strategy-book | 完了（https://github.com/itdojp/ai-testing-strategy-book/pull/66） | 進行中（直近: https://github.com/itdojp/ai-testing-strategy-book/pull/73） | レビュー文書: `docs/project-management/structure-review-round1.md` |
 | ai-communication-book | 完了（https://github.com/itdojp/ai-communication-book/pull/54） | 完了（直近: https://github.com/itdojp/ai-communication-book/pull/57） | レビュー文書: `docs/project-management/structure-review-round1.md` |
-| LogicalThinking-AI-Era-Guide | 完了（https://github.com/itdojp/LogicalThinking-AI-Era-Guide/pull/52） | パイロット（https://github.com/itdojp/LogicalThinking-AI-Era-Guide/pull/53） | ナビ整合: https://github.com/itdojp/LogicalThinking-AI-Era-Guide/pull/51 / レビュー文書: `docs/project-management/structure-review-round1.md` |
+| LogicalThinking-AI-Era-Guide | 完了（https://github.com/itdojp/LogicalThinking-AI-Era-Guide/pull/52） | 進行中（直近: https://github.com/itdojp/LogicalThinking-AI-Era-Guide/pull/56） | ナビ整合: https://github.com/itdojp/LogicalThinking-AI-Era-Guide/pull/51 / レビュー文書: `docs/project-management/structure-review-round1.md` |
 
 詳細なPR一覧は https://github.com/itdojp/it-engineer-knowledge-architecture/issues/51 を参照。
 


### PR DESCRIPTION
## 変更概要
- `project-management/content-improvement.md` の AI 系クラスタ（Issue #51）進捗表について、Stage3 の「直近PR」リンクを最新に更新しました。

## 更新内容
- `ai-testing-strategy-book`: 直近PRを #73 に更新
- `LogicalThinking-AI-Era-Guide`: Stage3 を「進行中」とし、直近PRを #56 に更新

## 関連
- https://github.com/itdojp/it-engineer-knowledge-architecture/issues/51
