### PR TITLE
docs: update linux cluster progress

### DIFF
--- a/project-management/content-improvement.md
+++ b/project-management/content-improvement.md
@@ -31,11 +31,17 @@
 
 | 書籍 | Stage2（構成レビュー） | Stage3（表現・スタイル） | 参照 |
 | --- | --- | --- | --- |
-| linux-infra-textbook2 | 完了（レビュー: https://github.com/itdojp/linux-infra-textbook2/pull/47 / 構成: https://github.com/itdojp/linux-infra-textbook2/pull/48） | 未着手 | レビュー文書: `docs/project-management/structure-review-round1.md` |
+| linux-infra-textbook2 | 完了（レビュー: https://github.com/itdojp/linux-infra-textbook2/pull/47 / 構成: https://github.com/itdojp/linux-infra-textbook2/pull/48） | 完了（直近: https://github.com/itdojp/linux-infra-textbook2/pull/63） | レビュー文書: `docs/project-management/structure-review-round1.md` / PR一覧: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/73 |
+
+## Linux 基礎クラスタ（Stage2/Stage3）進捗（Issue #75）
+
+| 書籍 | Stage2（構成レビュー） | Stage3（表現・スタイル） | 参照 |
+| --- | --- | --- | --- |
+| linux-infra-textbook | 未着手 | 未着手 | レビュー文書: `docs/project-management/structure-review-round1.md` |
 
 - [x] [illustrated-linux-basics-book](https://itdojp.github.io/illustrated-linux-basics-book/) — https://github.com/itdojp/illustrated-linux-basics-book
 - [x] [wsl2-linux-essentials-book](https://itdojp.github.io/wsl2-linux-essentials-book/) — https://github.com/itdojp/wsl2-linux-essentials-book
-- [ ] [linux-infra-textbook2](https://itdojp.github.io/linux-infra-textbook2/) — https://github.com/itdojp/linux-infra-textbook2
+- [x] [linux-infra-textbook2](https://itdojp.github.io/linux-infra-textbook2/) — https://github.com/itdojp/linux-infra-textbook2
 - [ ] [linux-infra-textbook](https://itdojp.github.io/linux-infra-textbook/) — https://github.com/itdojp/linux-infra-textbook
 - [ ] [it-infra-software-essentials-book](https://itdojp.github.io/it-infra-software-essentials-book/) — https://github.com/itdojp/it-infra-software-essentials-book
 - [ ] [IT-infra-book](https://itdojp.github.io/IT-infra-book/) — https://github.com/itdojp/IT-infra-book


### PR DESCRIPTION
linux-infra-textbook2 の Stage3 完了を進捗表に反映し、次の対象（linux-infra-textbook / Round5）を追記します。

- linux-infra-textbook2: Stage3 を「完了（直近PR）」に更新、チェックリストも更新
- linux-infra-textbook: Round5（Issue #75）の進捗表セクションを追加
