### PR TITLE
docs: add ethereum-learning-bootcamp to series

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Building Your Tech Career, One Book at a Time
 
 このプロジェクトは、ITエンジニア（特にインフラ系）が実務で必要とする知識を体系化し、段階的な学習ロードマップを提供することを目的としています。
 
-- 既存書籍: 26冊（レビュー済み）
+- 既存書籍: 27冊（レビュー済み）
 - 計画書籍: 7冊（新規制作予定）
-- 合計: 33冊による総合的な知識体系
+- 合計: 34冊による総合的な知識体系
 
 各書籍は GitHub リポジトリとして管理され、GitHub Pages を通じて無料で閲覧できる形に整備しています（公開準備中の書籍を除く）。  
 ライセンスは Creative Commons BY-NC-SA 4.0（非営利利用は自由、商用利用は別途契約）です。
@@ -88,7 +88,7 @@ Building Your Tech Career, One Book at a Time
 
 ## 書籍一覧
 
-### ✅ 既存書籍（26冊）
+### ✅ 既存書籍（27冊）
 
 #### 未経験者向け
 
@@ -205,6 +205,13 @@ Building Your Tech Career, One Book at a Time
 
 26. 計算論的物理主義
     [書籍を読む](https://itdojp.github.io/computational-physicalism-book/) | [リポジトリ](https://github.com/itdojp/computational-physicalism-book)
+
+#### Web3・ブロックチェーン
+
+対象: Web3 / ブロックチェーン / スマートコントラクト開発を学びたい方向け
+
+27. Ethereum学習ブートキャンプ
+    [書籍を読む](https://itdojp.github.io/ethereum-learning-bootcamp/) | [リポジトリ](https://github.com/itdojp/ethereum-learning-bootcamp)
 
 ---
 

--- a/books/existing-books.md
+++ b/books/existing-books.md
@@ -1,4 +1,4 @@
-# 既存書籍一覧（26冊）
+# 既存書籍一覧（27冊）
 
 ## 📚 書籍カテゴリ別整理
 
@@ -361,6 +361,22 @@
 - **前提知識**: 哲学・コンピュータサイエンス基礎
 - **学習期間**: 4-6週間
 
+### 🌐 Web3・ブロックチェーン（1冊）
+
+#### 27. **ethereum-learning-bootcamp**
+📖 [書籍を読む](https://itdojp.github.io/ethereum-learning-bootcamp/) | 📂 [リポジトリ](https://github.com/itdojp/ethereum-learning-bootcamp)
+- **タイトル**: Ethereum Learning Bootcamp
+- **対象読者**: Web3 / ブロックチェーン / Ethereum を学びたい初学者〜初級エンジニア（要確認）
+- **レビュー状況**: ✅ 公開済み
+- **主な内容**:
+  - Ethereum 基礎（トランザクション、ガス、L1/L2 など）
+  - Solidity 基礎
+  - ローカルテスト、デプロイ、CI
+  - DApp フロントエンド、The Graph、セキュリティ、ガス最適化、統合
+- **実務での重要度**: 中（Web3開発では高）
+- **前提知識**: プログラミング基礎（要確認）
+- **学習期間**: 要確認
+
 ## 📊 書籍マトリクス分析
 
 ### 難易度 × 重要度マトリクス
@@ -393,6 +409,7 @@
 - **ソフトウェア基礎**: it-infra-software-essentials-book
 - **コンテナ技術**: podman-book
 - **認証・セキュリティ**: practical-auth-book
+- **Web3・ブロックチェーン**: ethereum-learning-bootcamp
 - **開発プロセス**: github-workflow-book
 - **テスト戦略**: ai-testing-strategy-book  
 - **形式的手法**: formal-methods-book
@@ -428,6 +445,7 @@
 2. negotiation-for-engineers-book
 
 ### Phase 4: 専門分野（選択制）
+- ethereum-learning-bootcamp（Ethereum / Web3）
 - supabase-architecture-patterns-book（Supabase利用者）
 - BioinformaticsGuide-book（バイオ分野）
 - computational-physicalism-book（計算物理学・研究分野）
@@ -453,6 +471,6 @@
 
 ---
 
-既存22冊により、ITエンジニアの基礎から上級レベルまでの幅広い知識をカバーできています。特にインフラ基礎、クラウド技術、開発プロセス、ソフトスキルの分野では充実した内容となっています。
+既存27冊により、ITエンジニアの基礎から上級レベルまでの幅広い知識をカバーできています。特にインフラ基礎、クラウド技術、開発プロセス、ソフトスキルの分野では充実した内容となっています。
 
 **最新追加**: 形式的手法の基礎と応用により、高信頼性システム開発の分野が新たにカバーされました。これにより、安全クリティカルシステムや高品質ソフトウェア開発に関心のあるエンジニアにも対応できる、より包括的な体系となりました。理論計算機科学教科書と組み合わせることで、理論から実践まで一貫した学習パスが構築されています。

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,9 +29,9 @@ Building Your Tech Career, One Book at a Time
 
 このプロジェクトは、ITエンジニア（特にインフラ系）が実務で必要とする知識を体系化し、段階的な学習ロードマップを提供することを目的としています。
 
-- 既存書籍: 26冊（レビュー済み）
+- 既存書籍: 27冊（レビュー済み）
 - 計画書籍: 7冊（新規制作予定）
-- 合計: 33冊による総合的な知識体系
+- 合計: 34冊による総合的な知識体系
 
 各書籍は GitHub リポジトリとして管理され、GitHub Pages を通じて無料で閲覧できる形に整備しています（公開準備中の書籍を除く）。  
 ライセンスは Creative Commons BY-NC-SA 4.0（非営利利用は自由、商用利用は別途契約）です。
@@ -94,7 +94,7 @@ Building Your Tech Career, One Book at a Time
 
 ## 書籍一覧
 
-### ✅ 既存書籍（26冊）
+### ✅ 既存書籍（27冊）
 
 #### 未経験者向け
 
@@ -211,6 +211,13 @@ Building Your Tech Career, One Book at a Time
 
 26. 計算論的物理主義
     [書籍を読む](https://itdojp.github.io/computational-physicalism-book/) | [リポジトリ](https://github.com/itdojp/computational-physicalism-book)
+
+#### Web3・ブロックチェーン
+
+対象: Web3 / ブロックチェーン / スマートコントラクト開発を学びたい方向け
+
+27. Ethereum学習ブートキャンプ
+    [書籍を読む](https://itdojp.github.io/ethereum-learning-bootcamp/) | [リポジトリ](https://github.com/itdojp/ethereum-learning-bootcamp)
 
 ---
 


### PR DESCRIPTION
シリーズ書籍一覧に `ethereum-learning-bootcamp` を既存書籍として追加しました。

- 📖 Pages: https://itdojp.github.io/ethereum-learning-bootcamp/
- 📂 Repo: https://github.com/itdojp/ethereum-learning-bootcamp

合わせて冊数表記を更新（既存 27冊 / 合計 34冊）し、`docs/index.md` は `README.md` から再生成しています。