### PR TITLE
chore: 書籍一覧でAI系書籍を21-23に整列

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ Building Your Tech Career, One Book at a Time
 22. AI時代のプロフェッショナルITエンジニアの思考法  
     [書籍を読む](https://itdojp.github.io/ai-era-engineers-mind-book/) | [リポジトリ](https://github.com/itdojp/ai-era-engineers-mind-book)
 
-23. エンジニアの交渉力アーキテクチャ  
-    [書籍を読む](https://itdojp.github.io/negotiation-for-engineers-book/) | [リポジトリ](https://github.com/itdojp/negotiation-for-engineers-book)
-
-24. 生成AIコミュニケーション技術  
+23. 生成AIコミュニケーション技術  
     [書籍を読む](https://itdojp.github.io/ai-communication-book/) | [リポジトリ](https://github.com/itdojp/ai-communication-book)
+
+24. エンジニアの交渉力アーキテクチャ  
+    [書籍を読む](https://itdojp.github.io/negotiation-for-engineers-book/) | [リポジトリ](https://github.com/itdojp/negotiation-for-engineers-book)
 
 25. エンジニアのための実践コミュニケーション設計  
     [書籍を読む](https://itdojp.github.io/IT-engineer-communication-book/) | [リポジトリ](https://github.com/itdojp/IT-engineer-communication-book)
@@ -312,7 +312,7 @@ Linux基礎
 
 ### エンジニアリングマネージャー
 
-- ソフトスキル: AI時代に差がつく論理的思考と表現力 → AI時代のプロフェッショナルITエンジニアの思考法 → エンジニアの交渉力アーキテクチャ → 生成AIコミュニケーション技術  
+- ソフトスキル: AI時代に差がつく論理的思考と表現力 → AI時代のプロフェッショナルITエンジニアの思考法 → 生成AIコミュニケーション技術 → エンジニアの交渉力アーキテクチャ  
 - 技術理解: 基礎分野の概要習得 → 理論計算機科学教科書（理論的背景）  
 - 教養: デジタル革命の先駆者たち → 計算論的物理主義  
 
@@ -404,8 +404,8 @@ ITDO Inc. が公開する技術書籍は **Creative Commons BY-NC-SA 4.0** ラ�
 - バイオインフォマティクス実践ガイド – https://github.com/itdojp/BioinformaticsGuide-book  
 - AI時代に差がつく論理的思考と表現力 – https://github.com/itdojp/LogicalThinking-AI-Era-Guide  
 - AI時代のプロフェッショナルITエンジニアの思考法 – https://github.com/itdojp/ai-era-engineers-mind-book  
-- エンジニアの交渉力アーキテクチャ – https://github.com/itdojp/negotiation-for-engineers-book  
 - 生成AIコミュニケーション技術 – https://github.com/itdojp/ai-communication-book  
+- エンジニアの交渉力アーキテクチャ – https://github.com/itdojp/negotiation-for-engineers-book  
 - エンジニアのための実践コミュニケーション設計 – https://github.com/itdojp/IT-engineer-communication-book  
 - デジタル革命の先駆者たち – https://github.com/itdojp/cs-visionaries-book  
 - 計算論的物理主義 – https://github.com/itdojp/computational-physicalism-book  

--- a/books/existing-books.md
+++ b/books/existing-books.md
@@ -305,20 +305,7 @@
 - **前提知識**: エンジニア経験3年以上
 - **学習期間**: 5-6週間
 
-#### 23. **negotiation-for-engineers-book**
-📖 [書籍を読む](https://itdojp.github.io/negotiation-for-engineers-book/) | 📂 [リポジトリ](https://github.com/itdojp/negotiation-for-engineers-book)
-- **タイトル**: エンジニアの交渉力アーキテクチャ
-- **対象読者**: 中堅～シニアエンジニア・管理職
-- **レビュー状況**: ✅ Issue #1作成済み
-- **主な内容**:
-  - 技術的根拠による説得術
-  - ステークホルダー管理
-  - エンジニア特化の交渉手法
-- **実務での重要度**: 高
-- **前提知識**: エンジニア経験3年以上
-- **学習期間**: 4-5週間
-
-#### 24. **ai-communication-book**
+#### 23. **ai-communication-book**
 📖 [書籍を読む](https://itdojp.github.io/ai-communication-book/) | 📂 [リポジトリ](https://github.com/itdojp/ai-communication-book)
 - **タイトル**: 生成AIコミュニケーション技術
 - **対象読者**: エンジニア・ビジネスパーソン・コミュニケーション担当者
@@ -331,6 +318,19 @@
 - **実務での重要度**: 中
 - **前提知識**: なし
 - **学習期間**: 3-4週間
+
+#### 24. **negotiation-for-engineers-book**
+📖 [書籍を読む](https://itdojp.github.io/negotiation-for-engineers-book/) | 📂 [リポジトリ](https://github.com/itdojp/negotiation-for-engineers-book)
+- **タイトル**: エンジニアの交渉力アーキテクチャ
+- **対象読者**: 中堅～シニアエンジニア・管理職
+- **レビュー状況**: ✅ Issue #1作成済み
+- **主な内容**:
+  - 技術的根拠による説得術
+  - ステークホルダー管理
+  - エンジニア特化の交渉手法
+- **実務での重要度**: 高
+- **前提知識**: エンジニア経験3年以上
+- **学習期間**: 4-5週間
 
 #### 25. **IT-engineer-communication-book**
 📖 [書籍を読む](https://itdojp.github.io/IT-engineer-communication-book/) | 📂 [リポジトリ](https://github.com/itdojp/IT-engineer-communication-book)

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,11 +199,11 @@ Building Your Tech Career, One Book at a Time
 22. AI時代のプロフェッショナルITエンジニアの思考法  
     [書籍を読む](https://itdojp.github.io/ai-era-engineers-mind-book/) | [リポジトリ](https://github.com/itdojp/ai-era-engineers-mind-book)
 
-23. エンジニアの交渉力アーキテクチャ  
-    [書籍を読む](https://itdojp.github.io/negotiation-for-engineers-book/) | [リポジトリ](https://github.com/itdojp/negotiation-for-engineers-book)
-
-24. 生成AIコミュニケーション技術  
+23. 生成AIコミュニケーション技術  
     [書籍を読む](https://itdojp.github.io/ai-communication-book/) | [リポジトリ](https://github.com/itdojp/ai-communication-book)
+
+24. エンジニアの交渉力アーキテクチャ  
+    [書籍を読む](https://itdojp.github.io/negotiation-for-engineers-book/) | [リポジトリ](https://github.com/itdojp/negotiation-for-engineers-book)
 
 25. エンジニアのための実践コミュニケーション設計  
     [書籍を読む](https://itdojp.github.io/IT-engineer-communication-book/) | [リポジトリ](https://github.com/itdojp/IT-engineer-communication-book)
@@ -318,7 +318,7 @@ Linux基礎
 
 ### エンジニアリングマネージャー
 
-- ソフトスキル: AI時代に差がつく論理的思考と表現力 → AI時代のプロフェッショナルITエンジニアの思考法 → エンジニアの交渉力アーキテクチャ → 生成AIコミュニケーション技術  
+- ソフトスキル: AI時代に差がつく論理的思考と表現力 → AI時代のプロフェッショナルITエンジニアの思考法 → 生成AIコミュニケーション技術 → エンジニアの交渉力アーキテクチャ  
 - 技術理解: 基礎分野の概要習得 → 理論計算機科学教科書（理論的背景）  
 - 教養: デジタル革命の先駆者たち → 計算論的物理主義  
 
@@ -410,8 +410,8 @@ ITDO Inc. が公開する技術書籍は **Creative Commons BY-NC-SA 4.0** ラ�
 - バイオインフォマティクス実践ガイド – https://github.com/itdojp/BioinformaticsGuide-book  
 - AI時代に差がつく論理的思考と表現力 – https://github.com/itdojp/LogicalThinking-AI-Era-Guide  
 - AI時代のプロフェッショナルITエンジニアの思考法 – https://github.com/itdojp/ai-era-engineers-mind-book  
-- エンジニアの交渉力アーキテクチャ – https://github.com/itdojp/negotiation-for-engineers-book  
 - 生成AIコミュニケーション技術 – https://github.com/itdojp/ai-communication-book  
+- エンジニアの交渉力アーキテクチャ – https://github.com/itdojp/negotiation-for-engineers-book  
 - エンジニアのための実践コミュニケーション設計 – https://github.com/itdojp/IT-engineer-communication-book  
 - デジタル革命の先駆者たち – https://github.com/itdojp/cs-visionaries-book  
 - 計算論的物理主義 – https://github.com/itdojp/computational-physicalism-book  


### PR DESCRIPTION
書籍一覧の #23 と #24 を入れ替え、AI系3冊が #21-23 で連続するように整列しました。

- README.md / docs/index.md: 23/24 の順序を入れ替え（生成AIコミュニケーション技術 → 交渉力アーキテクチャ）
- books/existing-books.md: 23/24 のセクション順と番号を同様に入れ替え
- 学習パスのソフトスキル行も同順に調整
