### PR TITLE
fix(ci): harden quality sprint reminder workflow

### DIFF
--- a/.github/workflows/quality-sprint-reminder.yml
+++ b/.github/workflows/quality-sprint-reminder.yml
@@ -112,14 +112,16 @@ jobs:
           body = "\n".join(lines) + "\n"
 
           issue_path = f"/repos/{repo_full_name}/issues"
-          payload = {"title": title, "body": body, "labels": ["platform-wide"]}
+          payload = {"title": title, "body": body}
+
+          # Labels may not exist in forks; only include when available.
           try:
-              created = gh_api("POST", issue_path, payload)
+              gh_api("GET", f"/repos/{repo_full_name}/labels/platform-wide")
+              payload["labels"] = ["platform-wide"]
           except urllib.error.HTTPError as e:
-              # Labels may not exist in forks; retry without labels.
-              if e.code == 422:
-                  created = gh_api("POST", issue_path, {"title": title, "body": body})
-              else:
+              if e.code != 404:
                   raise
+
+          created = gh_api("POST", issue_path, payload)
           print("Created:", created.get("html_url"))
           PY


### PR DESCRIPTION
PR #104 のCopilotレビュー（後着）で指摘された点を反映します。

- `GITHUB_REPOSITORY` からリポジトリを導出し、検索クエリ/APIパスのハードコードを排除
- `book-registry.json` の `pages` を優先してチェックリストのPages URLを生成（欠損時は従来フォーマットへフォールバック）
- forks 等でラベルが未作成の場合を考慮し、issue作成をラベルなしでリトライ

関連（元PR）: https://github.com/itdojp/it-engineer-knowledge-architecture/pull/104