### PR TITLE
Add candidates for AI-era infra knowledge gaps (Issue #83)

### DIFF
--- a/books/planned-books.md
+++ b/books/planned-books.md
@@ -19,6 +19,21 @@
 6. **コンプライアンス対応** - 法規制・監査対応
 7. **次世代技術** - 将来への技術投資
 
+## 🧩 追加検討中（Issue #83）
+
+現時点の「計画書籍（7冊）」とは別枠の **追加候補** です。採否決定後に本ファイルへ正式反映します。
+
+- Kubernetes/クラウドネイティブ運用（候補）
+  - 例: Deployment/Service/Ingress、RBAC、NetworkPolicy、永続ストレージ、スケーリング、アップグレード/バックアップ/障害対応
+- Platform Engineering / GitOps（候補）
+  - 例: Argo CD/Flux 運用設計、テンプレート/カタログ、標準化と例外運用、Platform のSLO/セキュリティ境界
+- 生成AI/LLM基盤のインフラ設計・運用（LLMOps）（候補）
+  - 例: 推論サービング/スケーリング、GPU運用、変更管理（モデル/プロンプト/データ）、セキュリティ要求
+- 既存計画書籍への組み込み候補
+  - 監視・運用自動化: OpenTelemetry/分散トレーシング（SLI/SLOとの接続含む）
+
+詳細: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/83
+
 ## 📚 計画書籍詳細
 
 ### 🔴 優先度: 高（必須追加 - 4冊）

--- a/roadmap/learning-paths.md
+++ b/roadmap/learning-paths.md
@@ -17,6 +17,21 @@
 - マネジメントトラック対応
 - 技術トレンドへの適応力強化
 
+## 🧩 検討中の追加パス（Issue #83）
+
+以下は現行の学習パスに対する **追加候補** です（採否未決）。
+
+- Kubernetes/クラウドネイティブ運用
+  - 位置づけ案: Podman（コンテナ基礎）の次段、または中級者パスの専門深化として追加
+- Platform Engineering / GitOps
+  - 位置づけ案: GitHub運用/IaC/CI/CD の次段として、標準化とセルフサービス化を扱う
+- 生成AI/LLM基盤のインフラ設計・運用（LLMOps）
+  - 位置づけ案: エキスパートパスの先端技術（将来投資）として追加
+- 観測性の標準化（OpenTelemetry/分散トレーシング）
+  - 位置づけ案: 「インフラ監視・運用自動化」計画書籍に組み込み、SLI/SLO と接続
+
+詳細: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/83
+
 ## 📚 レベル別詳細学習パス
 
 ### 🌱 初級者パス（経験0-2年）


### PR DESCRIPTION
Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/83

変更内容
- 計画書籍一覧に「追加検討中（Issue #83）」セクションを追加（計画書籍7冊とは別枠の候補として明記）
  - books/planned-books.md
- 学習パスに「検討中の追加パス（Issue #83）」セクションを追加
  - roadmap/learning-paths.md

意図
- Kubernetes / Platform Engineering / LLMOps / OpenTelemetry を「候補」として可視化し、採否決定の議論を進めやすくする。
- 採否決定後に、計画書籍（冊数）・学習パスの正式構成へ反映する前提。
