### PR TITLE
book-registry: kubernetes-proxmox-to-cloud-book を追加

### DIFF
--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0",
-  "updatedAt": "2026-02-09",
+  "updatedAt": "2026-02-23",
   "modulesCatalog": [
     "quickStart",
     "readingGuide",
@@ -299,6 +299,22 @@
         "glossary": false
       },
       "notes": "暫定割当（要確認）"
+    },
+    "kubernetes-proxmox-to-cloud-book": {
+      "repo": "itdojp/kubernetes-proxmox-to-cloud-book",
+      "pages": "https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/",
+      "profile": "B",
+      "modules": {
+        "quickStart": true,
+        "readingGuide": true,
+        "checklistPack": true,
+        "troubleshootingFlow": true,
+        "conceptMap": false,
+        "figureIndex": true,
+        "legalNotice": false,
+        "glossary": true
+      },
+      "notes": "初期登録"
     },
     "linux-infra-textbook2": {
       "repo": "itdojp/linux-infra-textbook2",


### PR DESCRIPTION
## 変更内容\n- docs/publishing/book-registry.json に kubernetes-proxmox-to-cloud-book を追加\n- updatedAt を 2026-02-23 に更新\n\n## 公開URL\n- https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/ （2026-02-23 時点で 200 応答）\n\n## UX\n- profile: B\n- modules: quickStart/readingGuide/checklistPack/troubleshootingFlow/figureIndex/glossary\n