### PR TITLE
[codex] record font readability e2e follow-up

### DIFF
--- a/docs/publishing/follow-up-priorities.md
+++ b/docs/publishing/follow-up-priorities.md
@@ -49,7 +49,7 @@ description: 既存書籍レビュー後に残った横断・書籍別 follow-up
 | --- | --- | --- |
 | Kubernetes / コンテナ UX | [kubernetes-basics-book#22](https://github.com/itdojp/kubernetes-basics-book/issues/22)、[#13](https://github.com/itdojp/kubernetes-basics-book/issues/13)、[kubernetes-cluster-ops-book#16](https://github.com/itdojp/kubernetes-cluster-ops-book/issues/16)、[kubernetes-proxmox-to-cloud-book#20](https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/issues/20)、[podman-book#189](https://github.com/itdojp/podman-book/issues/189) | 章導線、共通コア、スクリーンショット差し込みを、書籍ごとに小粒 PR 化する |
 | Proxmox 図表・スクリーンショット | [proxmox_book#25](https://github.com/itdojp/proxmox_book/issues/25)、[#2](https://github.com/itdojp/proxmox_book/issues/2) | Proxmox VE の対象バージョンと取得手順を固定してから、図表追加 PR に進む |
-| 実機目視 / 可読性 | [it-engineer-knowledge-architecture#117](https://github.com/itdojp/it-engineer-knowledge-architecture/issues/117) | Pages Visual Check の artifact を使い、iOS Safari / Android Chrome / Windows ブラウザの観点を記録する |
+| 実機目視 / 可読性 | [it-engineer-knowledge-architecture#117](https://github.com/itdojp/it-engineer-knowledge-architecture/issues/117) | [フォント可読性 E2E 確認ログ（2026-05-24）](./font-readability-check-2026-05-24.html) を基準に、`fail=0` の維持と残 `warn=16`（4リポジトリ）の実機確認・書籍別PR化を進める |
 | Professional Foundations 整理 | [it-engineer-knowledge-architecture#126](https://github.com/itdojp/it-engineer-knowledge-architecture/issues/126) | カテゴリ導線、書籍企画対応表、相互リンク方針、横断テンプレートを `professional-foundations/` と `templates/professional-foundations/` に集約し、完了判断へ進める |
 
 ### P3: 整理・クローズ判断

--- a/docs/publishing/font-readability-check-2026-05-24.md
+++ b/docs/publishing/font-readability-check-2026-05-24.md
@@ -1,0 +1,101 @@
+---
+layout: default
+title: フォント可読性 E2E 確認ログ（2026-05-24）
+description: Issue #117 の Pages Visual Check 再実行結果、修正PR、残警告、実機目視への引き継ぎ
+---
+
+# フォント可読性 E2E 確認ログ（2026-05-24）
+
+関連: [Issue #117](https://github.com/itdojp/it-engineer-knowledge-architecture/issues/117)
+
+## 目的
+
+フォント統一後のフォローアップとして、現行 `docs/publishing/book-registry.json` に掲載されている 39 冊を対象に、モバイル相当の Pages Visual Check を再実行しました。
+本ログは、E2E で検出した font/runtime gate の失敗、対応PR、再実行結果、実機目視へ残す事項を記録するものです。
+
+## 実行条件
+
+| 項目 | 値 |
+| --- | --- |
+| 実行日 | 2026-05-24（Asia/Tokyo） |
+| 対象 | `docs/publishing/book-registry.json` 掲載 39 冊 |
+| browsers | `chromium,webkit` |
+| devices | `pixel7,iphone13` |
+| maxPagesPerBook | `4` |
+| captureSidebar | `true` |
+| enforceFontSpec | `true` |
+| Playwright | `tools/pages-visual-check/package.json` の `playwright@1.58.2` |
+
+再実行しやすいように、以下はリポジトリルートからの相対パスで表記しています。
+実際の確認では同等の workspace-local 一時ディレクトリを指定しました。
+
+```bash
+PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-./tmp/ms-playwright}" \
+node tools/pages-visual-check/run.mjs \
+  --registry docs/publishing/book-registry.json \
+  --output ./tmp/pages-visual-check-117-post-fixes-20260524 \
+  --browsers chromium,webkit \
+  --devices pixel7,iphone13 \
+  --maxPagesPerBook 4 \
+  --concurrency 3 \
+  --captureSidebar \
+  --enforceFontSpec
+```
+
+## 初回結果と修正
+
+初回実行では、39 冊 / 312 ページ中 `fail=16` を検出しました。
+主因は `computational-physicalism-book` と `cs-visionaries-book` の font/runtime gate 不整合でした。
+
+| リポジトリ | 検出内容 | 対応PR | 状態 |
+| --- | --- | --- | --- |
+| `itdojp/computational-physicalism-book` | `--font-sans` / `--font-mono` 欠落、存在しない `safe-main.js` 参照、classic script の `styleSheet` グローバル衝突 | [PR #143](https://github.com/itdojp/computational-physicalism-book/pull/143) | merged |
+| `itdojp/cs-visionaries-book` | `--font-sans` / `--font-mono` 欠落、存在しない `safe-main.js` 参照 | [PR #163](https://github.com/itdojp/cs-visionaries-book/pull/163) | merged |
+
+## Pages Visual Check ツールの補正
+
+一部の生成済み書籍レイアウトは、モバイルDrawerを `.active` ではなく `.is-open` と `window.sidebarManager.open()` で制御します。
+`--captureSidebar` が実際の UI 状態を確認できるように、Pages Visual Check は以下を許容します。
+
+- `#sidebar-toggle-checkbox` がある旧レイアウト
+- `#sidebar.active` を使うレイアウト
+- `#sidebar.is-open` を使うレイアウト
+- `window.sidebarManager.open()` を公開するレイアウト
+
+この補正により、UI 側では開けるDrawerを `sidebar did not open` と誤判定するケースを減らします。
+
+## 修正後の再実行結果
+
+修正PRのマージと Pages 反映後、同条件で再実行しました。
+
+| 指標 | 結果 |
+| --- | --- |
+| books | 39 |
+| pagesChecked | 312 |
+| ok | 296 |
+| warn | 16 |
+| fail | 0 |
+| globalWarn | 0 |
+
+`fail=0` となり、font/runtime gate の失敗は解消しました。
+
+## 残警告
+
+残る `warn=16` は、実機目視または書籍別 follow-up PR で扱う対象です。
+
+| リポジトリ | 警告 | 対象 |
+| --- | --- | --- |
+| `ai-agent-engineering-book` | Drawer open 時に active TOC が可視領域外 | Chapter 7 / Chapter 12、Pixel 7 / iPhone 13 |
+| `cs-visionaries-book` | モバイル横方向 overflow | root、Chapter 1 / 7 / 12、Pixel 7 / iPhone 13 |
+| `formal-methods-book` | モバイル横方向 overflow | Chapter 1 / 13、Pixel 7 / iPhone 13 |
+| `negotiation-for-engineers-book` | appendix log page の active TOC 不一致、`rel=prev/next` 欠落 | `appendices/logs/NEG-2024-06-10-001/`、Pixel 7 / iPhone 13 |
+
+## 実機目視への引き継ぎ
+
+この確認は Playwright の device emulation による E2E であり、実機 iOS Safari / Android Chrome / Windows Edge/Chrome の代替ではありません。
+Issue #117 の実機チェックは、以下の順序で消し込む必要があります。
+
+1. 本ログの残警告テーブルから対象ページを優先して開く。
+2. iOS Safari / Android Chrome / Windows Edge/Chrome で、TOC、前へ/次へ、本文、コード、SVG、テーブル、長いURLを確認する。
+3. 問題が再現する場合は該当書籍リポジトリへ小粒PRを作成する。
+4. 問題が再現しない場合も、端末名、OS、ブラウザ、確認ページ、判断理由を Issue #117 へコメントする。

--- a/docs/publishing/index.md
+++ b/docs/publishing/index.md
@@ -14,6 +14,7 @@ description: 書籍シリーズの体裁・構成・運用の標準
 - [版番号/更新履歴の運用](./versioning.md)
 - [運用プレイブック（book-formatter更新の横展開）](./operations-playbook.md)
 - [品質スプリント運用](./quality-sprint.md)
+- [フォント可読性 E2E 確認ログ（2026-05-24）](./font-readability-check-2026-05-24.html)
 - [新規書籍クイックスタート](./new-book-quickstart.md)
 - [Professional Foundations（基礎リテラシー）実装ガイド](../professional-foundations/)
 

--- a/tools/pages-visual-check/run.mjs
+++ b/tools/pages-visual-check/run.mjs
@@ -1008,6 +1008,13 @@ async function checkPage({
 
       if (captureSidebar) {
         try {
+          const isSidebarOpenInPage = () => {
+            const cb = document.getElementById('sidebar-toggle-checkbox');
+            if (cb && cb instanceof HTMLInputElement && cb.checked) return true;
+            const sidebar = document.getElementById('sidebar');
+            return Boolean(sidebar && (sidebar.classList.contains('active') || sidebar.classList.contains('is-open')));
+          };
+
           const checkbox = page.locator('#sidebar-toggle-checkbox');
           const hasCheckbox = (await checkbox.count()) > 0;
           if (hasCheckbox) {
@@ -1026,13 +1033,32 @@ async function checkPage({
           }
 
           let opened = await page
-            .evaluate(() => {
-              const cb = document.getElementById('sidebar-toggle-checkbox');
-              if (cb && cb instanceof HTMLInputElement && cb.checked) return true;
-              const sidebar = document.getElementById('sidebar');
-              return Boolean(sidebar && sidebar.classList.contains('active'));
-            })
+            .evaluate(isSidebarOpenInPage)
             .catch(() => false);
+
+          if (!opened) {
+            // Some generated book layouts expose a public SidebarManager API instead of
+            // a checkbox or `.active` class. Prefer the API so the captured state matches
+            // a user-opened drawer while avoiding brittle click/overlay timing.
+            const managerOpenRequested = await page
+              .evaluate(() => {
+                const manager = window.sidebarManager;
+                if (manager && typeof manager.open === 'function') {
+                  manager.open();
+                  return true;
+                }
+                return false;
+              })
+              .catch(() => false);
+
+            if (managerOpenRequested) {
+              await page.waitForTimeout(50);
+            }
+
+            opened = await page
+              .evaluate(isSidebarOpenInPage)
+              .catch(() => false);
+          }
 
           if (!opened) {
             // Fallback: click the toggle (some layouts use a label linked to the checkbox).
@@ -1044,12 +1070,7 @@ async function checkPage({
             await page.waitForTimeout(50);
 
             opened = await page
-              .evaluate(() => {
-                const cb = document.getElementById('sidebar-toggle-checkbox');
-                if (cb && cb instanceof HTMLInputElement && cb.checked) return true;
-                const sidebar = document.getElementById('sidebar');
-                return Boolean(sidebar && sidebar.classList.contains('active'));
-              })
+              .evaluate(isSidebarOpenInPage)
               .catch(() => false);
           }
 


### PR DESCRIPTION
## Summary
- Record the 2026-05-24 Pages Visual Check follow-up for font readability / runtime gates under `docs/publishing/`.
- Link the new report from the publishing index and the follow-up priority matrix.
- Update `tools/pages-visual-check/run.mjs` so `--captureSidebar` recognizes generated book layouts that use `#sidebar.is-open` and `window.sidebarManager.open()`.

## Context
- Related: #117
- Follow-up child fixes already merged:
  - itdojp/computational-physicalism-book#143 (`2e528c618533bafe9a8941d98f7846837d325fe8`)
  - itdojp/cs-visionaries-book#163 (`2f8d7a4d99ef9ed9ac6fecc8f35cf09cbbf51794`)
- Initial full run before child fixes: `books=39 pages=312 ok=287 warn=9 fail=16 globalWarn=0`.
- Post-fix full run with the patched visual checker: `books=39 pages=312 ok=296 warn=16 fail=0 globalWarn=0`.
- The remaining `warn=16` is intentionally documented as real-device / book-specific follow-up. This PR does not mark the iOS Safari, Android Chrome, or Windows real-device checks in #117 as complete.

## Validation
- `git diff --check`
- `node scripts/validate-ux-registry.js`
- `NPM_CONFIG_CACHE=/home/devuser/work/CodeX/booksB/.codex-local/tmp/npm-cache npx --yes markdownlint-cli --disable MD013 MD025 MD029 MD034 -- docs/publishing/font-readability-check-2026-05-24.md docs/publishing/index.md docs/publishing/follow-up-priorities.md`
- Liquid-aware local Markdown/rendered link check over `docs/**/*.md`
- `PLAYWRIGHT_BROWSERS_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/ms-playwright node tools/pages-visual-check/run.mjs --registry docs/publishing/book-registry.json --output /home/devuser/work/CodeX/booksB/.codex-local/tmp/pages-visual-check-117-dryrun-20260524 --browsers chromium,webkit --devices pixel7,iphone13 --maxPagesPerBook 1 --captureSidebar --enforceFontSpec --dryRun`
- `jekyll build --source docs --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/iteka-117-site --baseurl /it-engineer-knowledge-architecture`
- Built-site marker smoke for the new report, publishing index, and follow-up priority page

auto-generated-by: codex