### PR TITLE
Add sidebar overlap visual regression check

### DIFF
--- a/.github/workflows/pages-visual-check.yml
+++ b/.github/workflows/pages-visual-check.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "chromium"
       viewports:
-        description: "Viewports (comma-separated): mobile,tablet,desktop"
+        description: "Viewports (comma-separated): mobile,phone480,tablet,tablet820,laptop1024,desktop"
         required: false
         default: "mobile,desktop"
       devices:

--- a/docs/publishing/index.md
+++ b/docs/publishing/index.md
@@ -16,6 +16,7 @@ description: 書籍シリーズの体裁・構成・運用の標準
 - [運用ダッシュボード](./operations-dashboard.html)
 - [品質スプリント運用](./quality-sprint.md)
 - [フォント可読性 E2E 確認ログ（2026-05-24）](./font-readability-check-2026-05-24.html)
+- [Sidebar TOC overlap 調査ログ（2026-06-07）](./sidebar-overlap-investigation-2026-06-07.html)
 - [新規書籍クイックスタート](./new-book-quickstart.md)
 - [Professional Foundations（基礎リテラシー）実装ガイド](../professional-foundations/)
 

--- a/docs/publishing/sidebar-overlap-investigation-2026-06-07.md
+++ b/docs/publishing/sidebar-overlap-investigation-2026-06-07.md
@@ -1,0 +1,95 @@
+# Sidebar TOC overlap investigation (2026-06-07)
+
+## Scope
+
+This note records the initial investigation for Issue #168: mobile / tablet portrait layouts where a fixed left Table of Contents (TOC) sidebar overlaps article content.
+
+Issue #168 names `it-engineer-knowledge-architecture` as the initial investigation target and lists multiple potentially affected book repositories. The catalog site itself is a Jekyll landing site without a sidebar TOC, so the reader-facing overlap does **not** reproduce on `https://itdojp.github.io/it-engineer-knowledge-architecture/`. The defect does reproduce on several registered book sites that use the shared book layout.
+
+## Reproduction matrix
+
+Local Playwright probe, Chromium, 2026-06-07 JST. Widths are the issue-specified matrix; heights are fixed to realistic portrait / small-window values for measurement.
+
+| Target | 480px | 768px | 820px | 1024px | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| `formal-methods-book` chapter 1 | overlap | overlap | overlap | overlap | `#sidebar` fixed at x=0..280; `article.page-content` starts at x=16. |
+| `categorical-software-design-book` chapter 1 | overlap | overlap | overlap | overlap | `#sidebar` fixed at x=0..280; `article.page-content` starts at x=16. |
+| `BioinformaticsGuide-book` chapter introduction | overlap | overlap | overlap | overlap | `#sidebar` fixed at x=0..280; `article.page-content` starts at x=16. |
+| `theoretical-computer-science-textbook` introduction | overlap | overlap | overlap | overlap | `#sidebar` fixed at x=0..280; `article.page-content` starts at x=16. |
+| `it-engineer-knowledge-architecture` root | no sidebar | no sidebar | no sidebar | no sidebar | Catalog layout has no `#sidebar`. |
+
+Representative baseline screenshot captured by the existing visual checker:
+
+- `.codex-local/issue168-baseline/screenshots/formal-methods-book/chromium/tablet/chapters__chapter01.jpg`
+
+The screenshot shows the left TOC drawer covering the chapter title and body text at tablet portrait width.
+
+## Root cause
+
+The affected book sites import `mobile-responsive.css` at the top of `main.css`:
+
+```css
+@import url('./mobile-responsive.css');
+```
+
+CSS `@import` rules are applied before the remaining declarations in the importing stylesheet. Therefore later declarations in `main.css`, especially:
+
+```css
+.book-sidebar {
+  transform: translateX(0);
+}
+```
+
+override the mobile/tablet closed-drawer rule in `mobile-responsive.css`:
+
+```css
+@media (max-width: 1024px) {
+  .book-sidebar {
+    transform: translateX(-100%);
+  }
+}
+```
+
+The main content correctly removes the desktop left margin at `<=1024px`, but the sidebar is not translated off-canvas. The result is a fixed 280px sidebar overlaying article content.
+
+## Tooling change in this repository
+
+`tools/pages-visual-check` now includes an explicit `sidebarContentOverlap` check:
+
+- detects visible `#sidebar` / `.book-sidebar` elements;
+- detects article/content candidates such as `article`, `.page-content`, `.book-content`, and `main`;
+- reports a failure when a fixed/absolute/sticky sidebar geometrically overlaps the article content in the normal, closed-drawer page state;
+- adds issue-relevant viewport aliases: `phone480`, `tablet820`, and `laptop1024` in addition to the existing `mobile`, `tablet`, and `desktop` viewports.
+
+Useful command for the Issue #168 matrix:
+
+```bash
+cd tools/pages-visual-check
+node run.mjs \
+  --registry ../../docs/publishing/book-registry.json \
+  --browsers chromium \
+  --viewports phone480,tablet,tablet820,laptop1024,desktop \
+  --onlyBooks formal-methods-book,categorical-software-design-book,BioinformaticsGuide-book,theoretical-computer-science-textbook \
+  --maxPagesPerBook 2 \
+  --captureSidebar \
+  --enforceFontSpec
+```
+
+## Validation of the detector
+
+- Positive control: the command above fails on the four affected book sites at `phone480`, `tablet`, `tablet820`, and `laptop1024`, reporting messages such as `sidebar/content overlap: aside#sidebar.book-sidebar covers article.page-content`.
+- Negative control: the same four sites pass at the existing `desktop` viewport (`1280px`), so the check does not flag the intended desktop sidebar layout.
+- Catalog control: `it-engineer-knowledge-architecture` has no sidebar TOC and did not reproduce the overlap in the standalone probe.
+
+## Follow-up plan
+
+The detector is a guardrail. The reader-facing fix must be applied in affected book repositories by ensuring the closed-drawer rule wins at `<=1024px`, for example by strengthening or moving the mobile/tablet sidebar transform rule while preserving the desktop layout.
+
+Initial follow-up targets from Issue #168:
+
+1. `itdojp/formal-methods-book`
+2. `itdojp/categorical-software-design-book`
+3. `itdojp/BioinformaticsGuide-book`
+4. `itdojp/theoretical-computer-science-textbook`
+
+After those four are fixed, run the detector against the full registry to identify and file additional follow-up issues for any other registered book sites that still fail.

--- a/docs/publishing/sidebar-overlap-investigation-2026-06-07.md
+++ b/docs/publishing/sidebar-overlap-investigation-2026-06-07.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Sidebar TOC overlap investigation (2026-06-07)
+description: Issue #168 の sidebar TOC overlap 再現・原因・検証ログ
+---
+
 # Sidebar TOC overlap investigation (2026-06-07)
 
 ## Scope

--- a/tools/pages-visual-check/README.md
+++ b/tools/pages-visual-check/README.md
@@ -26,7 +26,7 @@ node run.mjs \
   --registry ../../docs/publishing/book-registry.json \
   --output ../../tmp/pages-visual-check \
   --browsers chromium,firefox \
-  --viewports mobile,tablet,desktop \
+  --viewports phone480,tablet,tablet820,laptop1024,desktop \
   --maxPagesPerBook 4 \
   --concurrency 2 \
   --captureSidebar \
@@ -62,6 +62,7 @@ node run.mjs \
 - `rel="prev"` / `rel="next"` の存在（root 以外で両方欠落は warn）
 - `.toc-link.active` が現在URLと一致しているか（TOC現在位置ハイライトの整合性。不一致は warn）
 - `--captureSidebar` 指定時、Drawer を開いた直後に `.toc-link.active` が可視領域内にあるか（可視領域外は warn）
+- `#sidebar` / `.book-sidebar` と `main` / `.book-main` などの本文領域が通常表示時に重なっていないか（重なりは fail）
 
 ## 目視観点（Artifacts screenshots のチェックポイント）
 

--- a/tools/pages-visual-check/run.mjs
+++ b/tools/pages-visual-check/run.mjs
@@ -961,7 +961,15 @@ async function checkPage({
       };
 
       const sidebarCandidate = firstVisible(['#sidebar', '.book-sidebar', '.sidebar', 'nav.sidebar']);
-      const contentCandidate = firstVisible(['article', '.page-content', '.book-content', 'main', '#main', '.book-main', '.content']);
+      const contentCandidate = firstVisible([
+        'article',
+        '.page-content',
+        '.book-content',
+        'main',
+        '#main',
+        '.book-main',
+        '.content'
+      ]);
       let sidebarContentOverlap = { overlap: false, area: 0, xOverlap: 0, yOverlap: 0 };
       if (sidebarCandidate?.element && contentCandidate?.element) {
         const sidebarRect = sidebarCandidate.element.getBoundingClientRect();

--- a/tools/pages-visual-check/run.mjs
+++ b/tools/pages-visual-check/run.mjs
@@ -12,7 +12,10 @@ const FONT_SPEC_PATH = path.join(REPO_ROOT, 'docs', 'FONT-SPECIFICATION.md');
 
 const DEFAULT_VIEWPORTS = {
   mobile: { width: 390, height: 844 },
+  phone480: { width: 480, height: 900 },
   tablet: { width: 768, height: 1024 },
+  tablet820: { width: 820, height: 1180 },
+  laptop1024: { width: 1024, height: 768 },
   desktop: { width: 1280, height: 720 }
 };
 
@@ -47,7 +50,7 @@ Options:
   --registry <path>         book-registry.json (default: repo docs/publishing/book-registry.json)
   --output <dir>            output dir (default: tools/pages-visual-check/output/<timestamp>)
   --browsers <list>         chromium,firefox,webkit (default: chromium)
-  --viewports <list>        mobile,tablet,desktop (default: mobile,desktop)
+  --viewports <list>        mobile,phone480,tablet,tablet820,laptop1024,desktop (default: mobile,desktop)
   --devices <list>          Playwright device names or aliases (default: off; when set, viewports are ignored)
   --maxPagesPerBook <n>     pages per book incl. root (default: 4)
   --concurrency <n>         concurrent books (default: 3)
@@ -624,6 +627,7 @@ function classifyIssues({
   emptyTocLinks,
   tocActive,
   tocActiveSidebarVisibility,
+  sidebarContentOverlap,
   horizontalOverflow,
   fontVars,
   expectedFontVars,
@@ -723,6 +727,14 @@ function classifyIssues({
     const current = tocActiveSidebarVisibility.currentPath ?? '';
     const activeText = tocActiveSidebarVisibility.activeText ?? '';
     issues.warn.push(`toc active not visible in sidebar viewport: current=${current} active="${activeText}"`);
+  }
+
+  if (sidebarContentOverlap?.overlap) {
+    const x = sidebarContentOverlap.xOverlap ?? '?';
+    const y = sidebarContentOverlap.yOverlap ?? '?';
+    const sidebar = sidebarContentOverlap.sidebar?.selector ?? 'sidebar';
+    const content = sidebarContentOverlap.content?.selector ?? 'content';
+    issues.fail.push(`sidebar/content overlap: ${sidebar} covers ${content} (${x}px x ${y}px)`);
   }
 
   if (horizontalOverflow?.overflow) {
@@ -901,6 +913,87 @@ async function checkPage({
         activeSamples
       };
 
+      const describeElement = (el, fallbackSelector) => {
+        if (!el || !(el instanceof Element)) return null;
+        const tag = (el.tagName || '').toLowerCase();
+        const id = el.id ? `#${el.id}` : '';
+        const cls =
+          typeof el.className === 'string' && el.className.trim()
+            ? `.${el.className.trim().split(/\s+/).slice(0, 3).join('.')}`
+            : '';
+        const rect = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        return {
+          selector: `${tag}${id}${cls}` || fallbackSelector,
+          rect: {
+            left: Math.round(rect.left),
+            top: Math.round(rect.top),
+            right: Math.round(rect.right),
+            bottom: Math.round(rect.bottom),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height)
+          },
+          position: style.position,
+          display: style.display,
+          visibility: style.visibility,
+          opacity: style.opacity,
+          transform: style.transform
+        };
+      };
+
+      const firstVisible = (selectors) => {
+        for (const selector of selectors) {
+          for (const el of document.querySelectorAll(selector)) {
+            const style = getComputedStyle(el);
+            const rect = el.getBoundingClientRect();
+            if (
+              rect.width > 1 &&
+              rect.height > 1 &&
+              style.display !== 'none' &&
+              style.visibility !== 'hidden' &&
+              Number(style.opacity || '1') > 0
+            ) {
+              return { element: el, selector };
+            }
+          }
+        }
+        return null;
+      };
+
+      const sidebarCandidate = firstVisible(['#sidebar', '.book-sidebar', '.sidebar', 'nav.sidebar']);
+      const contentCandidate = firstVisible(['article', '.page-content', '.book-content', 'main', '#main', '.book-main', '.content']);
+      let sidebarContentOverlap = { overlap: false, area: 0, xOverlap: 0, yOverlap: 0 };
+      if (sidebarCandidate?.element && contentCandidate?.element) {
+        const sidebarRect = sidebarCandidate.element.getBoundingClientRect();
+        const contentRect = contentCandidate.element.getBoundingClientRect();
+        const xOverlap = Math.max(
+          0,
+          Math.min(sidebarRect.right, contentRect.right) - Math.max(sidebarRect.left, contentRect.left)
+        );
+        const yOverlap = Math.max(
+          0,
+          Math.min(sidebarRect.bottom, contentRect.bottom) - Math.max(sidebarRect.top, contentRect.top)
+        );
+        const area = xOverlap * yOverlap;
+        const sidebarStyle = getComputedStyle(sidebarCandidate.element);
+        const contentStyle = getComputedStyle(contentCandidate.element);
+        const sidebarIsOverlayLike =
+          sidebarStyle.position === 'fixed' ||
+          sidebarStyle.position === 'absolute' ||
+          sidebarStyle.position === 'sticky';
+        const contentIsNotInsideSidebar = !sidebarCandidate.element.contains(contentCandidate.element);
+        sidebarContentOverlap = {
+          overlap: sidebarIsOverlayLike && contentIsNotInsideSidebar && area > 1,
+          area: Math.round(area),
+          xOverlap: Math.round(xOverlap),
+          yOverlap: Math.round(yOverlap),
+          sidebar: describeElement(sidebarCandidate.element, sidebarCandidate.selector),
+          content: describeElement(contentCandidate.element, contentCandidate.selector),
+          sidebarZIndex: sidebarStyle.zIndex,
+          contentZIndex: contentStyle.zIndex
+        };
+      }
+
       const docEl = document.documentElement;
       const scrollWidth = docEl.scrollWidth;
       const clientWidth = docEl.clientWidth;
@@ -943,6 +1036,7 @@ async function checkPage({
         brokenImages,
         emptyTocLinks,
         tocActive,
+        sidebarContentOverlap,
         horizontalOverflow: {
           overflow: overflowPx > 1,
           overflowPx,
@@ -971,6 +1065,7 @@ async function checkPage({
           currentNormalizedPath: '',
           activeSamples: []
         },
+        sidebarContentOverlap: { overlap: false, area: 0, xOverlap: 0, yOverlap: 0 },
         horizontalOverflow: { overflow: false, overflowPx: 0, scrollWidth: 0, clientWidth: 0, offenders: [] },
         prevNext: { prevHref: null, nextHref: null }
       };
@@ -1234,6 +1329,7 @@ async function checkPage({
     emptyTocLinks: evalResult.emptyTocLinks,
     tocActive: evalResult.tocActive,
     tocActiveSidebarVisibility,
+    sidebarContentOverlap: evalResult.sidebarContentOverlap,
     horizontalOverflow: evalResult.horizontalOverflow,
     fontVars: evalResult.fontVars,
     expectedFontVars,
@@ -1253,6 +1349,7 @@ async function checkPage({
     emptyTocLinks: evalResult.emptyTocLinks,
     tocActive: evalResult.tocActive,
     tocActiveSidebarVisibility,
+    sidebarContentOverlap: evalResult.sidebarContentOverlap,
     horizontalOverflow: evalResult.horizontalOverflow,
     consoleErrors,
     pageErrors,

--- a/tools/pages-visual-check/run.mjs
+++ b/tools/pages-visual-check/run.mjs
@@ -972,33 +972,64 @@ async function checkPage({
       ]);
       let sidebarContentOverlap = { overlap: false, area: 0, xOverlap: 0, yOverlap: 0 };
       if (sidebarCandidate?.element && contentCandidate?.element) {
-        const sidebarRect = sidebarCandidate.element.getBoundingClientRect();
-        const contentRect = contentCandidate.element.getBoundingClientRect();
-        const xOverlap = Math.max(
-          0,
-          Math.min(sidebarRect.right, contentRect.right) - Math.max(sidebarRect.left, contentRect.left)
-        );
-        const yOverlap = Math.max(
-          0,
-          Math.min(sidebarRect.bottom, contentRect.bottom) - Math.max(sidebarRect.top, contentRect.top)
-        );
+        const sidebar = sidebarCandidate.element;
+        const content = contentCandidate.element;
+        const sidebarRect = sidebar.getBoundingClientRect();
+        const contentRect = content.getBoundingClientRect();
+        const overlapLeft = Math.max(sidebarRect.left, contentRect.left);
+        const overlapTop = Math.max(sidebarRect.top, contentRect.top);
+        const overlapRight = Math.min(sidebarRect.right, contentRect.right);
+        const overlapBottom = Math.min(sidebarRect.bottom, contentRect.bottom);
+        const xOverlap = Math.max(0, overlapRight - overlapLeft);
+        const yOverlap = Math.max(0, overlapBottom - overlapTop);
         const area = xOverlap * yOverlap;
-        const sidebarStyle = getComputedStyle(sidebarCandidate.element);
-        const contentStyle = getComputedStyle(contentCandidate.element);
+        const sidebarStyle = getComputedStyle(sidebar);
+        const contentStyle = getComputedStyle(content);
         const sidebarIsOverlayLike =
           sidebarStyle.position === 'fixed' ||
           sidebarStyle.position === 'absolute' ||
           sidebarStyle.position === 'sticky';
-        const contentIsNotInsideSidebar = !sidebarCandidate.element.contains(contentCandidate.element);
+        const elementsAreSeparate = !sidebar.contains(content) && !content.contains(sidebar);
+
+        const viewportWidth = document.documentElement.clientWidth || window.innerWidth || 0;
+        const viewportHeight = document.documentElement.clientHeight || window.innerHeight || 0;
+        const samplePoints = [
+          [overlapLeft + xOverlap / 2, overlapTop + yOverlap / 2],
+          [
+            overlapLeft + Math.min(16, Math.max(1, xOverlap - 1)),
+            overlapTop + Math.min(16, Math.max(1, yOverlap - 1))
+          ],
+          [
+            overlapRight - Math.min(16, Math.max(1, xOverlap - 1)),
+            overlapBottom - Math.min(16, Math.max(1, yOverlap - 1))
+          ]
+        ].filter(([x, y]) => x >= 0 && y >= 0 && x < viewportWidth && y < viewportHeight);
+
+        const topSamples = samplePoints.map(([x, y]) => {
+          const topEl = document.elementFromPoint(x, y);
+          return {
+            x: Math.round(x),
+            y: Math.round(y),
+            top: describeElement(topEl, ''),
+            sidebarOnTop: Boolean(topEl && (topEl === sidebar || sidebar.contains(topEl))),
+            contentOnTop: Boolean(topEl && (topEl === content || content.contains(topEl)))
+          };
+        });
+        const sidebarCoversContent = topSamples.some((sample) => sample.sidebarOnTop && !sample.contentOnTop);
+
         sidebarContentOverlap = {
-          overlap: sidebarIsOverlayLike && contentIsNotInsideSidebar && area > 1,
+          overlap: sidebarIsOverlayLike && elementsAreSeparate && area > 1 && sidebarCoversContent,
           area: Math.round(area),
           xOverlap: Math.round(xOverlap),
           yOverlap: Math.round(yOverlap),
-          sidebar: describeElement(sidebarCandidate.element, sidebarCandidate.selector),
-          content: describeElement(contentCandidate.element, contentCandidate.selector),
+          sidebar: describeElement(sidebar, sidebarCandidate.selector),
+          content: describeElement(content, contentCandidate.selector),
           sidebarZIndex: sidebarStyle.zIndex,
-          contentZIndex: contentStyle.zIndex
+          contentZIndex: contentStyle.zIndex,
+          sidebarIsOverlayLike,
+          elementsAreSeparate,
+          sidebarCoversContent,
+          topSamples
         };
       }
 


### PR DESCRIPTION
## Summary
- add Issue #168 viewport aliases (`phone480`, `tablet820`, `laptop1024`) to the Pages visual checker
- add a `sidebarContentOverlap` failure check that detects visible fixed/overlay sidebars covering article content in the normal closed-drawer state
- document the 2026-06-07 root-cause investigation and link it from the publishing guide

## Root cause found
The affected registered book sites import `mobile-responsive.css` at the top of `main.css`. Because imported CSS is applied before the rest of `main.css`, the later `.book-sidebar { transform: translateX(0); }` declaration wins over the mobile/tablet closed-drawer rule. As a result, the fixed 280px sidebar remains visible while article content starts near x=16 at 480/768/820/1024px.

## Verification
- `npm ci` in `tools/pages-visual-check`
- `node --check tools/pages-visual-check/run.mjs`
- `git diff --check`
- Positive control (expected failure):
  - `node run.mjs --registry ../../docs/publishing/book-registry.json --output ../../.codex-local/issue168-detection-check --browsers chromium --viewports phone480,tablet,tablet820,laptop1024,desktop --onlyBooks formal-methods-book,categorical-software-design-book,BioinformaticsGuide-book,theoretical-computer-science-textbook --maxPagesPerBook 2 --concurrency 2 --skipScreenshots --enforceFontSpec`
  - Result: `books=4 pages=40 ok=8 warn=0 fail=32`; failures are all at 480/768/820/1024px with `sidebar/content overlap`.
- Negative control:
  - `node run.mjs --registry ../../docs/publishing/book-registry.json --output ../../.codex-local/issue168-desktop-control --browsers chromium --viewports desktop --onlyBooks formal-methods-book,categorical-software-design-book,BioinformaticsGuide-book,theoretical-computer-science-textbook --maxPagesPerBook 2 --concurrency 2 --skipScreenshots --enforceFontSpec`
  - Result: `books=4 pages=8 ok=8 warn=0 fail=0`.

## Follow-up
This PR adds the detector and investigation report in the architecture repository. The reader-facing CSS fix still needs to be applied to the affected book repositories listed in the report.

Refs #168