### PR TITLE
[codex] Handle private books in progress report

### DIFF
--- a/docs/progress_report.md
+++ b/docs/progress_report.md
@@ -1,13 +1,14 @@
 # 📊 IT Engineer Knowledge Architecture 進捗レポート
 
-**更新日時**: 2026年07月04日 09:38:05 JST
+**更新日時**: 2026年07月04日 13:19:01 JST
 
 ## 📈 全体統計
 
 - **総書籍数**: 41冊
 - **アクティブ書籍**: 40冊
 - **アーカイブ書籍**: 0冊
-- **利用不可**: 1冊
+- **Private管理書籍**: 1冊
+- **利用不可**: 0冊
 - **総Open Issue数**: 6件
 - **総Open PR数**: 0件
 - **総Star数**: 1個
@@ -16,13 +17,13 @@
 
 | 書籍名 | Pages | Repo | ステータス | 最終更新 | Open Issues | Open PRs | Stars |
 |---|---|---|---|---|---:|---:|---:|
-| BioinformaticsGuide-book | [読む](https://itdojp.github.io/BioinformaticsGuide-book/) | [GitHub](https://github.com/itdojp/BioinformaticsGuide-book) | unavailable | N/A | 0 | 0 | 0 |
+| BioinformaticsGuide-book | [読む](https://itdojp.github.io/BioinformaticsGuide-book/) | [GitHub](https://github.com/itdojp/BioinformaticsGuide-book) | active | 2026-06-27T05:17:33Z | 0 | 0 | 0 |
 | GitHub-AgentOps-book | [読む](https://itdojp.github.io/GitHub-AgentOps-book/) | [GitHub](https://github.com/itdojp/GitHub-AgentOps-book) | active | 2026-06-26T23:08:47Z | 0 | 0 | 0 |
 | IT-engineer-communication-book | [読む](https://itdojp.github.io/IT-engineer-communication-book/) | [GitHub](https://github.com/itdojp/IT-engineer-communication-book) | active | 2026-06-26T23:08:47Z | 0 | 0 | 0 |
 | IT-infra-book | [読む](https://itdojp.github.io/IT-infra-book/) | [GitHub](https://github.com/itdojp/IT-infra-book) | active | 2026-06-26T23:45:08Z | 0 | 0 | 0 |
 | IT-infra-troubleshooting-book | [読む](https://itdojp.github.io/IT-infra-troubleshooting-book/) | [GitHub](https://github.com/itdojp/IT-infra-troubleshooting-book) | active | 2026-06-26T23:26:37Z | 0 | 0 | 0 |
 | LogicalThinking-AI-Era-Guide | [読む](https://itdojp.github.io/LogicalThinking-AI-Era-Guide/) | [GitHub](https://github.com/itdojp/LogicalThinking-AI-Era-Guide) | active | 2026-06-26T23:45:08Z | 0 | 0 | 0 |
-| ai-agent-collaboration-book | [読む（公開版）](https://itdojp.github.io/ai-agent-collaboration-book/) | Private（有料部分を含むため非公開） | active / private repo | 2026-07-01T01:47:02Z | 0 | 0 | 0 |
+| ai-agent-collaboration-book | [読む（無料公開範囲）](https://itdojp.github.io/ai-agent-collaboration-book/) | 有料部分を含むため管理リポジトリは Private。 | private | N/A | 0 | 0 | 0 |
 | ai-agent-engineering-book | [読む](https://itdojp.github.io/ai-agent-engineering-book/) | [GitHub](https://github.com/itdojp/ai-agent-engineering-book) | active | 2026-06-27T05:17:36Z | 0 | 0 | 0 |
 | ai-communication-book | [読む](https://itdojp.github.io/ai-communication-book/) | [GitHub](https://github.com/itdojp/ai-communication-book) | active | 2026-06-28T04:03:12Z | 1 | 0 | 0 |
 | ai-era-engineers-mind-book | [読む](https://itdojp.github.io/ai-era-engineers-mind-book/) | [GitHub](https://github.com/itdojp/ai-era-engineers-mind-book) | active | 2026-06-27T03:13:49Z | 0 | 0 | 0 |

--- a/scripts/generate-progress-report.js
+++ b/scripts/generate-progress-report.js
@@ -44,6 +44,22 @@ function formatJst(date) {
   return `${y}年${m}月${d}日 ${hh}:${mm}:${ss} JST`;
 }
 
+function firstSentence(text) {
+  const normalized = String(text || "").trim();
+  if (!normalized) {
+    return "";
+  }
+  const japanesePeriod = normalized.indexOf("。");
+  if (japanesePeriod >= 0) {
+    return normalized.slice(0, japanesePeriod + 1);
+  }
+  const englishPeriod = normalized.indexOf(". ");
+  if (englishPeriod >= 0) {
+    return normalized.slice(0, englishPeriod + 1);
+  }
+  return normalized;
+}
+
 function githubGraphql({ token, query }) {
   const payload = JSON.stringify({ query });
 
@@ -196,26 +212,45 @@ async function main() {
   const entries = Object.keys(books)
     .sort()
     .map((bookName) => {
-      const repo = books[bookName]?.repo;
-      const pages = books[bookName]?.pages;
+      const entry = books[bookName] || {};
+      const repo = entry.repo;
+      const pages = entry.pages;
+      const repoVisibility = entry.repoVisibility || "public";
       if (!repo || typeof repo !== "string") {
         fail(`${bookName}: repo が不正です`);
       }
       if (!pages || typeof pages !== "string") {
         fail(`${bookName}: pages が不正です`);
       }
+      if (!["public", "private"].includes(repoVisibility)) {
+        fail(`${bookName}: repoVisibility が不正です (${repoVisibility})`);
+      }
       const [owner, name] = repo.split("/");
       if (!owner || !name) {
         fail(`${bookName}: repo の形式が不正です (${repo})`);
       }
-      return { bookName, owner, name, repo, pages };
+      return {
+        bookName,
+        owner,
+        name,
+        repo,
+        pages,
+        repoVisibility,
+        pagesPublicationScope: entry.pagesPublicationScope || null,
+        accessNote: entry.accessNote || null,
+        isPrivateManaged: repoVisibility === "private",
+      };
     });
 
   // Fetch repository metadata in GraphQL batches to reduce API calls.
+  // Intentionally private management repositories are skipped: the catalog
+  // workflow token cannot read them, and they should not be treated as broken
+  // public repositories.
   const batchSize = 20;
   const repoInfoByFullName = new Map();
-  for (let i = 0; i < entries.length; i += batchSize) {
-    const batch = entries.slice(i, i + batchSize);
+  const queryEntries = entries.filter((e) => !e.isPrivateManaged);
+  for (let i = 0; i < queryEntries.length; i += batchSize) {
+    const batch = queryEntries.slice(i, i + batchSize);
     const query = buildRepoBatchQuery(batch);
     const res = await githubGraphqlWithRetry({ token, query });
     const data = res?.json?.data || {};
@@ -229,6 +264,19 @@ async function main() {
 
   const rows = entries.map((e) => {
     const fullName = `${e.owner}/${e.name}`;
+
+    if (e.isPrivateManaged) {
+      return {
+        ...e,
+        status: "private",
+        updatedAt: null,
+        openIssues: 0,
+        openPRs: 0,
+        stars: 0,
+        isArchived: false,
+      };
+    }
+
     const repoData = repoInfoByFullName.get(fullName) || null;
 
     if (!repoData) {
@@ -258,6 +306,7 @@ async function main() {
   const totalBooks = rows.length;
   const activeBooks = rows.filter((r) => r.status === "active").length;
   const archivedBooks = rows.filter((r) => r.status === "archived").length;
+  const privateBooks = rows.filter((r) => r.status === "private").length;
   const unavailableBooks = rows.filter((r) => r.status === "unavailable").length;
   const totalOpenIssues = rows.reduce((acc, r) => acc + (r.openIssues || 0), 0);
   const totalOpenPRs = rows.reduce((acc, r) => acc + (r.openPRs || 0), 0);
@@ -276,6 +325,7 @@ async function main() {
   md.push(`- **総書籍数**: ${totalBooks}冊`);
   md.push(`- **アクティブ書籍**: ${activeBooks}冊`);
   md.push(`- **アーカイブ書籍**: ${archivedBooks}冊`);
+  md.push(`- **Private管理書籍**: ${privateBooks}冊`);
   md.push(`- **利用不可**: ${unavailableBooks}冊`);
   md.push(`- **総Open Issue数**: ${totalOpenIssues}件`);
   md.push(`- **総Open PR数**: ${totalOpenPRs}件`);
@@ -289,8 +339,15 @@ async function main() {
   md.push("|---|---|---|---|---|---:|---:|---:|");
 
   for (const r of rows) {
-    const pagesLink = `[読む](${r.pages})`;
-    const repoLink = `[GitHub](https://github.com/${r.repo})`;
+    const pagesLabel =
+      r.pagesPublicationScope === "free-preview-aligned-with-zenn-free-scope"
+        ? "読む（無料公開範囲）"
+        : "読む";
+    const pagesLink = `[${pagesLabel}](${r.pages})`;
+    const repoLink =
+      r.status === "private"
+        ? firstSentence(r.accessNote) || "Private"
+        : `[GitHub](https://github.com/${r.repo})`;
     md.push(
       `| ${r.bookName} | ${pagesLink} | ${repoLink} | ${r.status} | ${
         r.updatedAt || "N/A"
@@ -318,6 +375,7 @@ async function main() {
         totalBooks,
         activeBooks,
         archivedBooks,
+        privateBooks,
         unavailableBooks,
         totalOpenIssues,
         totalOpenPRs,
@@ -325,7 +383,10 @@ async function main() {
         books: rows.map((r) => ({
           name: r.bookName,
           repo: r.repo,
+          repoVisibility: r.repoVisibility,
           pages: r.pages,
+          pagesPublicationScope: r.pagesPublicationScope,
+          accessNote: r.accessNote,
           status: r.status,
           updatedAt: r.updatedAt,
           openIssues: r.openIssues,


### PR DESCRIPTION
## Summary

- Teach `scripts/generate-progress-report.js` to treat `repoVisibility: "private"` entries as an intentional `private` status instead of querying them as unavailable public repositories.
- Skip private management repositories in the GitHub GraphQL batch so the catalog workflow token does not create false unavailable alerts.
- Regenerate `docs/progress_report.md` with a `Private管理書籍` count and the private/free-preview row for `ai-agent-collaboration-book`.

## Review feedback addressed

Follow-up for PR #174 automated review comments:

- Private paid-edition repositories must not be counted as unavailable.
- `docs/progress_report.md` should be generated from registry metadata rather than manually diverging from the generator.

## Validation

- `node scripts/validate-ux-registry.js docs/publishing/book-registry.json`
- `GITHUB_TOKEN=$(gh auth token) node scripts/generate-progress-report.js`
- `git diff --check`
- JSON/report assertions for `privateBooks == 1`, `unavailableBooks == 0`, and `ai-agent-collaboration-book.status == "private"`
- Local equivalent of the learning-path book-count check
