### PR TITLE
Add catalog source of truth and validation

### DIFF
--- a/.github/workflows/quality-sprint-reminder.yml
+++ b/.github/workflows/quality-sprint-reminder.yml
@@ -75,18 +75,22 @@ jobs:
               print(f"Skip: issue already exists: {url}")
               raise SystemExit(0)
 
-          registry_path = Path("docs/publishing/book-registry.json")
-          registry = json.loads(registry_path.read_text(encoding="utf-8"))
-          books = registry.get("books") or {}
-          # Build checklist links from the registry to avoid hard-coding Pages URL format.
+          catalog_path = Path("docs/_data/catalog.json")
+          catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+          books = catalog.get("books") or []
+          # Build checklist links from the catalog to avoid hard-coding Pages URL format.
+          # Phase 8 will narrow this to 2-4 selected books; this migration only
+          # switches the metadata source of truth.
           repo_to_pages = {}
-          for meta in books.values():
-              if not isinstance(meta, dict):
+          for meta in books:
+              if not isinstance(meta, dict) or meta.get("status") != "published":
+                  continue
+              if meta.get("countingGroup") != "main-lineup" or meta.get("countedInMainLineup") is not True:
                   continue
               repo = meta.get("repo")
               if not repo:
                   continue
-              pages = (meta.get("pages") or "").strip()
+              pages = (meta.get("pagesUrl") or "").strip()
               if repo not in repo_to_pages or (not repo_to_pages[repo] and pages):
                   repo_to_pages[repo] = pages
 

--- a/.github/workflows/validate-learning-paths.yml
+++ b/.github/workflows/validate-learning-paths.yml
@@ -6,11 +6,25 @@ on:
     paths:
       - 'roadmap/**'
       - 'books/**'
+      - 'docs/_data/**'
+      - 'docs/publishing/book-registry.json'
+      - 'schemas/**'
+      - 'scripts/**'
+      - 'tests/fixtures/**'
+      - 'package.json'
+      - 'package-lock.json'
   pull_request:
     branches: [ main ]
     paths:
       - 'roadmap/**'
       - 'books/**'
+      - 'docs/_data/**'
+      - 'docs/publishing/book-registry.json'
+      - 'schemas/**'
+      - 'scripts/**'
+      - 'tests/fixtures/**'
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   validate-learning-paths:
@@ -26,62 +40,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: 検証スクリプト実行
-        run: |
-          set -euo pipefail
+      - name: npm依存関係確認
+        run: npm ci
 
-          echo "📚 書籍リスト整合性チェック中..."
-
-          if [ ! -f books/existing-books.md ] || [ ! -f books/planned-books.md ]; then
-            echo "❌ エラー: books/existing-books.md または books/planned-books.md が見つかりません"
-            exit 1
-          fi
-
-          # books/* から冊数を算出
-          existing_books=$(grep -E "^#### [0-9]+\\. \\*\\*" books/existing-books.md | wc -l | tr -d ' ')
-          planned_books=$(grep -E "^#### [0-9]+\\." books/planned-books.md | wc -l | tr -d ' ')
-          total_books=$((existing_books + planned_books))
-
-          echo "既存書籍数（books/existing-books.md）: $existing_books"
-          echo "計画書籍数（books/planned-books.md）: $planned_books"
-          echo "総書籍数: $total_books"
-
-          # README/docs の宣言値と整合性を確認（存在する場合のみ）
-          readme_existing=$(grep -E "^- 既存書籍: [0-9]+冊" README.md | head -n 1 | grep -oE "[0-9]+" || true)
-          readme_planned=$(grep -E "^- 計画書籍: [0-9]+冊" README.md | head -n 1 | grep -oE "[0-9]+" || true)
-          readme_total=$(grep -E "^- 合計: [0-9]+冊" README.md | head -n 1 | grep -oE "[0-9]+" || true)
-
-          docs_existing=$(grep -E "^- 既存書籍: [0-9]+冊" docs/index.md | head -n 1 | grep -oE "[0-9]+" || true)
-          docs_planned=$(grep -E "^- 計画書籍: [0-9]+冊" docs/index.md | head -n 1 | grep -oE "[0-9]+" || true)
-          docs_total=$(grep -E "^- 合計: [0-9]+冊" docs/index.md | head -n 1 | grep -oE "[0-9]+" || true)
-
-          if [ -n "${readme_existing:-}" ] && [ "$readme_existing" -ne "$existing_books" ]; then
-            echo "❌ エラー: README.md の既存書籍数が一致しません（README: $readme_existing / books: $existing_books）"
-            exit 1
-          fi
-          if [ -n "${readme_planned:-}" ] && [ "$readme_planned" -ne "$planned_books" ]; then
-            echo "❌ エラー: README.md の計画書籍数が一致しません（README: $readme_planned / books: $planned_books）"
-            exit 1
-          fi
-          if [ -n "${readme_total:-}" ] && [ "$readme_total" -ne "$total_books" ]; then
-            echo "❌ エラー: README.md の合計書籍数が一致しません（README: $readme_total / 計算値: $total_books）"
-            exit 1
-          fi
-
-          if [ -n "${docs_existing:-}" ] && [ "$docs_existing" -ne "$existing_books" ]; then
-            echo "❌ エラー: docs/index.md の既存書籍数が一致しません（docs: $docs_existing / books: $existing_books）"
-            exit 1
-          fi
-          if [ -n "${docs_planned:-}" ] && [ "$docs_planned" -ne "$planned_books" ]; then
-            echo "❌ エラー: docs/index.md の計画書籍数が一致しません（docs: $docs_planned / books: $planned_books）"
-            exit 1
-          fi
-          if [ -n "${docs_total:-}" ] && [ "$docs_total" -ne "$total_books" ]; then
-            echo "❌ エラー: docs/index.md の合計書籍数が一致しません（docs: $docs_total / 計算値: $total_books）"
-            exit 1
-          fi
-
-          echo "✅ 書籍数チェック通過"
+      - name: カタログ正本・学習グラフ検証
+        run: npm run verify
 
       - name: マークダウンリンクチェック
         run: |
@@ -120,24 +83,6 @@ jobs:
 
           echo "✅ リンクチェック通過"
 
-      - name: 学習パス循環参照チェック
-        run: |
-          echo "🔄 学習パス循環参照チェック中..."
-
-          # 簡単な循環参照チェック（前提知識の循環）
-          # 実際の実装では、より詳細なグラフ解析が必要
-
-          echo "✅ 循環参照チェック通過"
-
-      - name: 前提知識整合性チェック
-        run: |
-          echo "📋 前提知識整合性チェック中..."
-
-          # 前提知識に記載された書籍が実際に存在するかチェック
-          # これは簡単な例で、実際にはより詳細な解析が必要
-
-          echo "✅ 前提知識整合性チェック通過"
-
   validate-yaml-structure:
     runs-on: ubuntu-latest
     name: YAML構造検証
@@ -165,31 +110,37 @@ jobs:
       - name: チェックアウト
         uses: actions/checkout@v4
 
+      - name: Node.js設定
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: 学習パス統計生成
         run: |
-          echo "📊 学習パス統計情報生成中..."
-
-          # 書籍カテゴリ別統計
-          echo "## 📚 書籍統計" > stats.md
-          echo "" >> stats.md
-
-          # 技術基盤書籍数
-          tech_books=$(grep -E "### 🔧 技術基盤" books/existing-books.md -A 20 | grep -E "^#### \d+\." | wc -l || echo "0")
-          echo "- 技術基盤: ${tech_books}冊" >> stats.md
-
-          # 開発・運用プロセス書籍数
-          process_books=$(grep -E "### 🔄 開発・運用プロセス" books/existing-books.md -A 20 | grep -E "^#### \d+\." | wc -l || echo "0")
-          echo "- 開発・運用プロセス: ${process_books}冊" >> stats.md
-
-          # ソフトスキル書籍数
-          soft_books=$(grep -E "### 💡 ソフトスキル・思考法" books/existing-books.md -A 20 | grep -E "^#### \d+\." | wc -l || echo "0")
-          echo "- ソフトスキル・思考法: ${soft_books}冊" >> stats.md
-
-          echo "" >> stats.md
-          echo "最終更新: $(date '+%Y-%m-%d %H:%M:%S')" >> stats.md
-
-          echo "✅ 統計情報生成完了"
-          cat stats.md
+          node - <<'NODE'
+          const fs = require('fs');
+          const catalog = JSON.parse(fs.readFileSync('docs/_data/catalog.json', 'utf8'));
+          const books = catalog.books || [];
+          const expected = catalog.expectedCounts || {};
+          const main = books.filter((b) => b.countingGroup === 'main-lineup' && b.countedInMainLineup).length;
+          const planned = books.filter((b) => b.countingGroup === 'planned').length;
+          const related = books.filter((b) => b.countingGroup === 'related-independent').length;
+          const categories = new Map();
+          for (const book of books) categories.set(book.category, (categories.get(book.category) || 0) + 1);
+          const lines = [];
+          lines.push('## 📚 書籍統計');
+          lines.push('');
+          lines.push(`- メインライン公開書籍: ${main}冊`);
+          lines.push(`- 計画書籍: ${planned}冊`);
+          lines.push(`- 関連する独立書籍: ${related}冊`);
+          lines.push('');
+          lines.push('### カテゴリ別');
+          for (const [category, count] of [...categories].sort()) lines.push(`- ${category}: ${count}件`);
+          lines.push('');
+          lines.push(`期待値: main=${expected.mainLineup}, planned=${expected.planned}, relatedIndependent=${expected.relatedIndependent}`);
+          fs.writeFileSync('stats.md', lines.join('\n') + '\n');
+          console.log(lines.join('\n'));
+          NODE
 
       - name: 統計をアーティファクトとして保存
         uses: actions/upload-artifact@v4

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1,0 +1,3540 @@
+{
+  "schemaVersion": "1.0.0",
+  "updatedAt": "2026-07-10",
+  "sourcePolicy": {
+    "canonical": "docs/_data/catalog.json",
+    "derivedFiles": [
+      "docs/publishing/book-registry.json"
+    ],
+    "externalDynamicFields": [
+      "stars",
+      "openIssues",
+      "updatedAtFromGitHub",
+      "openPRs",
+      "repoAvailabilityStatus"
+    ],
+    "notes": "GitHub APIから取得するStar数、Open Issue数、リポジトリ更新日時は正本へ保存しない。"
+  },
+  "expectedCounts": {
+    "mainLineup": 41,
+    "planned": 7,
+    "relatedIndependent": 1
+  },
+  "moduleCatalog": [
+    "quickStart",
+    "readingGuide",
+    "checklistPack",
+    "troubleshootingFlow",
+    "conceptMap",
+    "figureIndex",
+    "legalNotice",
+    "glossary"
+  ],
+  "books": [
+    {
+      "id": "illustrated-linux-basics-book",
+      "displayOrder": 1,
+      "title": {
+        "ja": "図解でわかるLinux基礎",
+        "en": "図解でわかるLinux基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/illustrated-linux-basics-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/illustrated-linux-basics-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "A visual introduction to Linux basics, core commands, filesystems, networking, and containers."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "wsl2-linux-essentials-book",
+      "displayOrder": 2,
+      "title": {
+        "ja": "やさしく学ぶLinux WSL2ではじめる基礎",
+        "en": "やさしく学ぶLinux WSL2ではじめる基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/wsl2-linux-essentials-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/wsl2-linux-essentials-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Uses WSL2 on Windows as a safe learning environment for Linux setup, shell usage, processes, networking, and scripting."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "evidence-based-engineering-book",
+      "displayOrder": 3,
+      "title": {
+        "ja": "根拠で進める開発仕事術：検索戦略・検証・引用の実務",
+        "en": "根拠で進める開発仕事術：検索戦略・検証・引用の実務"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/evidence-based-engineering-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/evidence-based-engineering-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "professional-foundations",
+      "subcategory": "基礎リテラシー（Professional Foundations）",
+      "tags": [
+        "professional-foundations"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers"
+      ],
+      "audiences": [
+        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Explains how to search, verify, quote, and document evidence so engineering decisions stay defensible."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "issue-driven-work-book",
+      "displayOrder": 4,
+      "title": {
+        "ja": "チケット駆動の仕事術：良いIssueとPRで回すタスク管理・報告・合意形成",
+        "en": "チケット駆動の仕事術：良いIssueとPRで回すタスク管理・報告・合意形成"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/issue-driven-work-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/issue-driven-work-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "professional-foundations",
+      "subcategory": "基礎リテラシー（Professional Foundations）",
+      "tags": [
+        "professional-foundations"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers"
+      ],
+      "audiences": [
+        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Shows how to manage work with high-quality issues and pull requests for tracking, reporting, and consensus building."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "engineering-documentation-book",
+      "displayOrder": 5,
+      "title": {
+        "ja": "エンジニアリングドキュメント実践ガイド：README・手順書・Runbook・ADR・ポストモーテム",
+        "en": "エンジニアリングドキュメント実践ガイド：README・手順書・Runbook・ADR・ポストモーテム"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/engineering-documentation-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/engineering-documentation-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "professional-foundations",
+      "subcategory": "基礎リテラシー（Professional Foundations）",
+      "tags": [
+        "professional-foundations"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers"
+      ],
+      "audiences": [
+        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Covers practical engineering documents such as READMEs, procedures, runbooks, ADRs, and postmortems."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "security-privacy-literacy-book",
+      "displayOrder": 6,
+      "title": {
+        "ja": "セキュリティ＆プライバシー基礎リテラシー：秘密情報・権限・データ取り扱い",
+        "en": "セキュリティ＆プライバシー基礎リテラシー：秘密情報・権限・データ取り扱い"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/security-privacy-literacy-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/security-privacy-literacy-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "professional-foundations",
+      "subcategory": "基礎リテラシー（Professional Foundations）",
+      "tags": [
+        "professional-foundations"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers"
+      ],
+      "audiences": [
+        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Introduces everyday security and privacy practice around secrets, permissions, and responsible data handling."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "incident-response-basics-book",
+      "displayOrder": 7,
+      "title": {
+        "ja": "インシデント対応 基礎：切り分け・状況共有・復旧・ポストモーテムの型",
+        "en": "インシデント対応 基礎：切り分け・状況共有・復旧・ポストモーテムの型"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/incident-response-basics-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/incident-response-basics-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "professional-foundations",
+      "subcategory": "基礎リテラシー（Professional Foundations）",
+      "tags": [
+        "professional-foundations"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers"
+      ],
+      "audiences": [
+        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Provides a reusable incident response pattern from initial triage through communication, recovery, and postmortem review."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "linux-infra-textbook2",
+      "displayOrder": 8,
+      "title": {
+        "ja": "実践Linux インフラエンジニア入門",
+        "en": "実践Linux インフラエンジニア入門"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/linux-infra-textbook2",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/linux-infra-textbook2/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "core-infra-foundations",
+      "subcategory": "技術基盤（基礎）",
+      "tags": [
+        "core-infra-foundations"
+      ],
+      "levels": [
+        "junior",
+        "intermediate"
+      ],
+      "roles": [
+        "infrastructure-engineer"
+      ],
+      "audiences": [
+        "新人〜中級者（経験0–2年）/ ITインフラの土台となる必修知識"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Builds Linux infrastructure fundamentals for modern operations, including systems, networking, process management, and security basics."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "linux-infra-textbook を置換（旧版はアーカイブ）",
+        "日本語個別概要はREADME公開カタログ上で未記載。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "it-infra-software-essentials-book",
+      "displayOrder": 9,
+      "title": {
+        "ja": "ITインフラエンジニアのためのソフトウェア基礎知識",
+        "en": "ITインフラエンジニアのためのソフトウェア基礎知識"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/it-infra-software-essentials-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/it-infra-software-essentials-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "core-infra-foundations",
+      "subcategory": "技術基盤（基礎）",
+      "tags": [
+        "core-infra-foundations"
+      ],
+      "levels": [
+        "junior",
+        "intermediate"
+      ],
+      "roles": [
+        "infrastructure-engineer"
+      ],
+      "audiences": [
+        "新人〜中級者（経験0–2年）/ ITインフラの土台となる必修知識"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Explains the software concepts infrastructure engineers need for packages, code reading, APIs, databases, and runtime behavior."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "IT-infra-book",
+      "displayOrder": 10,
+      "title": {
+        "ja": "ITインフラストラクチャ技術ガイド",
+        "en": "ITインフラストラクチャ技術ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/IT-infra-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/IT-infra-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "core-infra-foundations",
+      "subcategory": "技術基盤（基礎）",
+      "tags": [
+        "core-infra-foundations"
+      ],
+      "levels": [
+        "junior",
+        "intermediate"
+      ],
+      "roles": [
+        "infrastructure-engineer"
+      ],
+      "audiences": [
+        "新人〜中級者（経験0–2年）/ ITインフラの土台となる必修知識"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Organizes the design principles behind protocols, networks, operating systems, and storage for infrastructure engineers."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "IT-infra-troubleshooting-book",
+      "displayOrder": 11,
+      "title": {
+        "ja": "ITインフラトラブルシューティング実践ガイド",
+        "en": "ITインフラトラブルシューティング実践ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/IT-infra-troubleshooting-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/IT-infra-troubleshooting-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "advanced-infra-practice",
+      "subcategory": "技術基盤（発展）",
+      "tags": [
+        "advanced-infra-practice"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "sre"
+      ],
+      "audiences": [
+        "中級〜上級者（経験2年以上）/ 高度な設計・運用・問題解決スキル"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Teaches systematic troubleshooting through hypothesis building, observation, isolation, verification, and recovery."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "cloud-infra-book",
+      "displayOrder": 12,
+      "title": {
+        "ja": "クラウドインフラ設計・構築ガイド",
+        "en": "クラウドインフラ設計・構築ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/cloud-infra-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/cloud-infra-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "advanced-infra-practice",
+      "subcategory": "技術基盤（発展）",
+      "tags": [
+        "advanced-infra-practice"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "sre"
+      ],
+      "audiences": [
+        "中級〜上級者（経験2年以上）/ 高度な設計・運用・問題解決スキル"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Focuses on designing and building cloud infrastructure with sound choices for compute, storage, networking, and operations."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "it-infra-security-guide-book",
+      "displayOrder": 13,
+      "title": {
+        "ja": "インフラエンジニアのための情報セキュリティ実装ガイド",
+        "en": "インフラエンジニアのための情報セキュリティ実装ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/it-infra-security-guide-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/it-infra-security-guide-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "security",
+      "subcategory": "セキュリティ",
+      "tags": [
+        "security"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "security-engineer",
+        "infrastructure-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / インフラ・アプリケーションのセキュリティ設計・診断"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Covers practical security controls for infrastructure, including identity, hardening, monitoring, and incident readiness."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "pentest-learning-book",
+      "displayOrder": 14,
+      "title": {
+        "ja": "実務で使えるペネトレーションテスト大全",
+        "en": "実務で使えるペネトレーションテスト大全"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/pentest-learning-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/pentest-learning-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "security",
+      "subcategory": "セキュリティ",
+      "tags": [
+        "security"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "security-engineer",
+        "infrastructure-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / インフラ・アプリケーションのセキュリティ設計・診断"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Introduces penetration testing workflows, tooling, and reporting for real-world security assessments."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "proxmox_book",
+      "displayOrder": 15,
+      "title": {
+        "ja": "Proxmox VE 実践ガイド",
+        "en": "Proxmox VE 実践ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/proxmox_book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/proxmox_book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "applied-technologies",
+      "subcategory": "応用技術",
+      "tags": [
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "backend-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / 特定技術スタックの実践的活用"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Explains how to build and operate virtualization environments with Proxmox VE in practical scenarios."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "kubernetes-basics-book",
+      "displayOrder": 16,
+      "title": {
+        "ja": "Kubernetes入門：PodからIngressまで（基礎と実践）",
+        "en": "Kubernetes入門：PodからIngressまで（基礎と実践）"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/kubernetes-basics-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/kubernetes-basics-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "applied-technologies",
+      "subcategory": "応用技術",
+      "tags": [
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "backend-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / 特定技術スタックの実践的活用"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Introduces Kubernetes from core objects to service exposure, with hands-on operational basics."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "初期登録",
+        "日本語個別概要はREADME公開カタログ上で未記載。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "kubernetes-cluster-ops-book",
+      "displayOrder": 17,
+      "title": {
+        "ja": "Kubernetesクラスタ設計・運用実践ガイド",
+        "en": "Kubernetesクラスタ設計・運用実践ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/kubernetes-cluster-ops-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/kubernetes-cluster-ops-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "applied-technologies",
+      "subcategory": "応用技術",
+      "tags": [
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "backend-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / 特定技術スタックの実践的活用"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Covers Kubernetes cluster design and day-2 operations with reliability, lifecycle, and security concerns in mind."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "初期登録",
+        "日本語個別概要はREADME公開カタログ上で未記載。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "kubernetes-proxmox-to-cloud-book",
+      "displayOrder": 18,
+      "title": {
+        "ja": "Kubernetes: Proxmox検証からクラウド本番へ",
+        "en": "Kubernetes: Proxmox検証からクラウド本番へ"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/kubernetes-proxmox-to-cloud-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "applied-technologies",
+      "subcategory": "応用技術",
+      "tags": [
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "backend-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / 特定技術スタックの実践的活用"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Bridges local Proxmox-based Kubernetes experiments to cloud production architecture and operations."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "初期登録",
+        "日本語個別概要はREADME公開カタログ上で未記載。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "podman-book",
+      "displayOrder": 19,
+      "title": {
+        "ja": "Podman完全ガイド",
+        "en": "Podman完全ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/podman-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/podman-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "applied-technologies",
+      "subcategory": "応用技術",
+      "tags": [
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "backend-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / 特定技術スタックの実践的活用"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Explains Podman-based container workflows, including images, storage, networking, pods, and rootless operation."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "practical-auth-book",
+      "displayOrder": 20,
+      "title": {
+        "ja": "実践 認証認可システム設計",
+        "en": "実践 認証認可システム設計"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/practical-auth-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/practical-auth-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "applied-technologies",
+      "subcategory": "応用技術",
+      "tags": [
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "backend-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / 特定技術スタックの実践的活用"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Designs authentication and authorization systems from sessions and tokens to OAuth 2.0, OIDC, and federated identity."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "supabase-architecture-patterns-book",
+      "displayOrder": 21,
+      "title": {
+        "ja": "Supabaseアーキテクチャ",
+        "en": "Supabaseアーキテクチャ"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/supabase-architecture-patterns-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/supabase-architecture-patterns-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "applied-technologies",
+      "subcategory": "応用技術",
+      "tags": [
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "backend-engineer"
+      ],
+      "audiences": [
+        "中級者以上 / 特定技術スタックの実践的活用"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Uses Supabase as a practical application platform covering auth, data, edge functions, and operations."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "theoretical-computer-science-prerequisites-book",
+      "displayOrder": 22,
+      "title": {
+        "ja": "理論計算機科学を読むための数学・証明・アルゴリズム基礎",
+        "en": "Mathematics, Proofs, and Algorithms for Reading Theoretical Computer Science"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/theoretical-computer-science-prerequisites-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/theoretical-computer-science-prerequisites-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "computer-science-theory",
+      "subcategory": "コンピューターサイエンス理論",
+      "tags": [
+        "computer-science-theory"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "software-engineer",
+        "architect"
+      ],
+      "audiences": [
+        "中級者以上 / 理論的バックグラウンドの深化"
+      ],
+      "summary": {
+        "ja": "集合・論理・関数・関係・証明技法・漸近記法・擬似コード・グラフ・組合せ・データ構造・形式言語・確率・数論・線形代数・並行モデルを、理論計算機科学教科書に進むための前提として整理するブリッジ教材。",
+        "en": "A Japanese bridge textbook for readers who need prerequisites before studying theoretical computer science: sets, logic, proofs, asymptotic notation, graphs, counting, data structures, formal languages, probability, number theory, linear algebra, and concurrency models."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": true,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": true,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "理論計算機科学教科書の前提補強ブリッジ教材"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "theoretical-computer-science-textbook",
+      "displayOrder": 23,
+      "title": {
+        "ja": "理論計算機科学教科書",
+        "en": "理論計算機科学教科書"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/theoretical-computer-science-textbook",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/theoretical-computer-science-textbook/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "computer-science-theory",
+      "subcategory": "コンピューターサイエンス理論",
+      "tags": [
+        "computer-science-theory"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "software-engineer",
+        "architect"
+      ],
+      "audiences": [
+        "中級者以上 / 理論的バックグラウンドの深化"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Builds a foundation in algorithms, automata, computability, and complexity theory."
+      },
+      "prerequisites": [
+        "theoretical-computer-science-prerequisites-book"
+      ],
+      "estimatedWeeks": null,
+      "recommendedAfter": [
+        "theoretical-computer-science-prerequisites-book"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "categorical-software-design-book",
+      "displayOrder": 24,
+      "title": {
+        "ja": "圏論によるAIエージェント時代の合成的ソフトウェア設計",
+        "en": "圏論によるAIエージェント時代の合成的ソフトウェア設計"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/categorical-software-design-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/categorical-software-design-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "computer-science-theory",
+      "subcategory": "コンピューターサイエンス理論",
+      "tags": [
+        "computer-science-theory"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "software-engineer",
+        "architect"
+      ],
+      "audiences": [
+        "中級者以上 / 理論的バックグラウンドの深化"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Japanese book focused on category-theoretic design for the AI agent era. It stands alongside the separate English book *Compositional Software Design for Agentic Systems* rather than serving as an older edition or a direct translation."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [
+        "composable-software-design-book"
+      ],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": true,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": true,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "Profile C の暫定割当。付録Dは図版・レビュー前の最小確認項目・症状別再参照の入口として扱う。raw サンプルは本文より先に更新される場合があるため要確認。",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。",
+        "独立英語書籍 composable-software-design-book と関連。単純翻訳・旧新版関係ではない。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "github-guide-for-beginners-book",
+      "displayOrder": 25,
+      "title": {
+        "ja": "GitHub初心者ガイド",
+        "en": "GitHub初心者ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/github-guide-for-beginners-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/github-guide-for-beginners-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "development-delivery",
+      "subcategory": "開発・運用プロセス",
+      "tags": [
+        "development-delivery"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "software-engineer",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / 開発効率化・品質向上"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Introduces GitHub basics for repositories, branching, pull requests, and team collaboration."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "github-workflow-book",
+      "displayOrder": 26,
+      "title": {
+        "ja": "AI開発のためのGitHubワークフロー実践ガイド",
+        "en": "AI開発のためのGitHubワークフロー実践ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/github-workflow-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/github-workflow-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "development-delivery",
+      "subcategory": "開発・運用プロセス",
+      "tags": [
+        "development-delivery"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "software-engineer",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / 開発効率化・品質向上"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Shows how to use GitHub workflows, automation, and AI-assisted review in modern software delivery."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "GitHub-AgentOps-book",
+      "displayOrder": 27,
+      "title": {
+        "ja": "GitHub AgentOps 実践ガイド",
+        "en": "GitHub AgentOps 実践ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/GitHub-AgentOps-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/GitHub-AgentOps-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "development-delivery",
+      "subcategory": "開発・運用プロセス",
+      "tags": [
+        "development-delivery"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "software-engineer",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / 開発効率化・品質向上"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Organizes GitHub-centered AgentOps practices for prompts, reviews, governance, and operational control of AI agents."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "ai-agent-collaboration-book",
+      "displayOrder": 28,
+      "title": {
+        "ja": "AIエージェント協働の仕事術",
+        "en": "AIエージェント協働の仕事術"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/ai-agent-collaboration-book",
+      "repoVisibility": "private",
+      "pagesUrl": "https://itdojp.github.io/ai-agent-collaboration-book/",
+      "publicationScope": "free-preview",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "development-delivery",
+      "subcategory": "開発・運用プロセス",
+      "tags": [
+        "development-delivery"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "software-engineer",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / 開発効率化・品質向上"
+      ],
+      "summary": {
+        "ja": "AIエージェントを業務成果へ接続するための依頼、コンテキスト、委任、レビュー、権限、判断、組織展開の実践フレームワーク。GitHub Pages は Zenn 等で無料公開する範囲に準じた試読範囲を公開する方針です。",
+        "en": "Provides a practical framework for turning AI agents into work outcomes through request contracts, context packs, delegation, review, permissions, human judgment, and organizational rollout. GitHub Pages is intended to publish only the free-preview scope aligned with the Zenn free-publication boundary."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": true,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "AIエージェントを業務成果へ接続する依頼・文脈・委任・検証・権限・判断・組織展開の横断書籍。無料公開範囲と有料版を分けて運用する。",
+        "有料部分を含むPrivate管理書籍。Pagesは無料公開範囲のみ。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "ai-agent-engineering-book",
+      "displayOrder": 29,
+      "title": {
+        "ja": "AIエージェント実践: Prompt / Context / Harness Engineering",
+        "en": "AI Agent Engineering in Practice: Prompt / Context / Harness Engineering"
+      },
+      "officialEnglishTitle": "AI Agent Engineering in Practice: Prompt / Context / Harness Engineering",
+      "status": "published",
+      "repo": "itdojp/ai-agent-engineering-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/ai-agent-engineering-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "development-delivery",
+      "subcategory": "開発・運用プロセス",
+      "tags": [
+        "development-delivery"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "software-engineer",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / 開発効率化・品質向上"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Covers prompt contracts, context engineering, and harness design so AI agents can read repos, make changes, verify results, and complete work safely."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja",
+        "en"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": false,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）/ 英語版あり",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。",
+        "同一書籍内に英語版ページあり。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "ai-testing-strategy-book",
+      "displayOrder": 30,
+      "title": {
+        "ja": "AI主導開発時代のソフトウェアテスト戦略",
+        "en": "AI主導開発時代のソフトウェアテスト戦略"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/ai-testing-strategy-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/ai-testing-strategy-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "development-delivery",
+      "subcategory": "開発・運用プロセス",
+      "tags": [
+        "development-delivery"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "software-engineer",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / 開発効率化・品質向上"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Designs test strategy for AI-assisted and AI-based development with risk-based coverage and fast feedback loops."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "formal-methods-book",
+      "displayOrder": 31,
+      "title": {
+        "ja": "形式的手法の基礎と応用",
+        "en": "形式的手法の基礎と応用"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/formal-methods-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/formal-methods-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "development-delivery",
+      "subcategory": "開発・運用プロセス",
+      "tags": [
+        "development-delivery"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "software-engineer",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / 開発効率化・品質向上"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Introduces formal methods from specification to model checking and proof-oriented reasoning."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "small-webapp-software-design-book",
+      "displayOrder": 32,
+      "title": {
+        "ja": "要件から始めるソフトウェア設計（小規模TS Webアプリの実践）",
+        "en": "要件から始めるソフトウェア設計（小規模TS Webアプリの実践）"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/small-webapp-software-design-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/small-webapp-software-design-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "development-delivery",
+      "subcategory": "開発・運用プロセス",
+      "tags": [
+        "development-delivery"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "software-engineer",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / 開発効率化・品質向上"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Starts software design from requirements and turns a small TypeScript web app into a coherent, reviewable structure."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "BioinformaticsGuide-book",
+      "displayOrder": 33,
+      "title": {
+        "ja": "バイオインフォマティクス実践ガイド",
+        "en": "バイオインフォマティクス実践ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/BioinformaticsGuide-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/BioinformaticsGuide-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "domain-specific",
+      "subcategory": "特定領域・ドメイン知識",
+      "tags": [
+        "domain-specific"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "domain-engineer"
+      ],
+      "audiences": [
+        "専門分野従事者 / 業界特化の専門知識"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Bridges IT engineering and bioinformatics through workflows, data handling, and practical case studies."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "LogicalThinking-AI-Era-Guide",
+      "displayOrder": 34,
+      "title": {
+        "ja": "AI時代に差がつく論理的思考と表現力",
+        "en": "AI時代に差がつく論理的思考と表現力"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/LogicalThinking-AI-Era-Guide",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/LogicalThinking-AI-Era-Guide/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "soft-skills-thinking",
+      "subcategory": "ソフトスキル・思考法",
+      "tags": [
+        "soft-skills-thinking"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / キャリア発展・コミュニケーション"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Improves logic, structure, and expression for clearer thinking and communication in the AI era."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "ai-era-engineers-mind-book",
+      "displayOrder": 35,
+      "title": {
+        "ja": "AI時代のプロフェッショナルITエンジニアの思考法",
+        "en": "AI時代のプロフェッショナルITエンジニアの思考法"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/ai-era-engineers-mind-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/ai-era-engineers-mind-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "soft-skills-thinking",
+      "subcategory": "ソフトスキル・思考法",
+      "tags": [
+        "soft-skills-thinking"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / キャリア発展・コミュニケーション"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Focuses on professional judgment, habits, and decision-making for IT engineers working in the AI era."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "ai-communication-book",
+      "displayOrder": 36,
+      "title": {
+        "ja": "生成AIコミュニケーション技術",
+        "en": "生成AIコミュニケーション技術"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/ai-communication-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/ai-communication-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "soft-skills-thinking",
+      "subcategory": "ソフトスキル・思考法",
+      "tags": [
+        "soft-skills-thinking"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / キャリア発展・コミュニケーション"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Explains how to communicate effectively with generative AI through prompts, context control, and collaborative patterns."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "negotiation-for-engineers-book",
+      "displayOrder": 37,
+      "title": {
+        "ja": "エンジニアの交渉力アーキテクチャ",
+        "en": "エンジニアの交渉力アーキテクチャ"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/negotiation-for-engineers-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/negotiation-for-engineers-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "soft-skills-thinking",
+      "subcategory": "ソフトスキル・思考法",
+      "tags": [
+        "soft-skills-thinking"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / キャリア発展・コミュニケーション"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Treats negotiation as an engineering skill built from structure, trade-offs, and shared understanding."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "IT-engineer-communication-book",
+      "displayOrder": 38,
+      "title": {
+        "ja": "エンジニアのための実践コミュニケーション設計",
+        "en": "エンジニアのための実践コミュニケーション設計"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/IT-engineer-communication-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/IT-engineer-communication-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "soft-skills-thinking",
+      "subcategory": "ソフトスキル・思考法",
+      "tags": [
+        "soft-skills-thinking"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers",
+        "engineering-manager"
+      ],
+      "audiences": [
+        "全レベル / キャリア発展・コミュニケーション"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Designs practical communication for engineers across teams, stakeholders, and delivery work."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "B",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": false,
+          "checklistPack": true,
+          "troubleshootingFlow": true,
+          "conceptMap": false,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": false
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "cs-visionaries-book",
+      "displayOrder": 39,
+      "title": {
+        "ja": "デジタル革命の先駆者たち",
+        "en": "デジタル革命の先駆者たち"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/cs-visionaries-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/cs-visionaries-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "liberal-arts-philosophy",
+      "subcategory": "教養・哲学",
+      "tags": [
+        "liberal-arts-philosophy"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers"
+      ],
+      "audiences": [
+        "全レベル / 技術的教養・視野拡大"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Introduces key people and ideas that shaped the digital revolution and modern computing culture."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": false,
+          "figureIndex": false,
+          "legalNotice": true,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "人物史中心の導入書として暫定 Profile A。reader-facing な正本はトップページの目次を基準とし、付録C/付録Dは補助資料として扱う。AI 関連の主導入は第10章で、技術史の深掘りは付録Cと関連人物章を併用する。",
+        "日本語個別概要はREADME公開カタログ上で未記載。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "computational-physicalism-book",
+      "displayOrder": 40,
+      "title": {
+        "ja": "計算論的物理主義",
+        "en": "計算論的物理主義"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/computational-physicalism-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/computational-physicalism-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "liberal-arts-philosophy",
+      "subcategory": "教養・哲学",
+      "tags": [
+        "liberal-arts-philosophy"
+      ],
+      "levels": [
+        "all-levels"
+      ],
+      "roles": [
+        "all-engineers"
+      ],
+      "audiences": [
+        "全レベル / 技術的教養・視野拡大"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Explores computational physicalism and its implications for mind, intelligence, and engineered systems."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "C",
+        "modules": {
+          "quickStart": false,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": true,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "ethereum-learning-bootcamp",
+      "displayOrder": 41,
+      "title": {
+        "ja": "Ethereum学習ブートキャンプ",
+        "en": "Ethereum学習ブートキャンプ"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/ethereum-learning-bootcamp",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/ethereum-learning-bootcamp/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "web3-blockchain",
+      "subcategory": "Web3・ブロックチェーン",
+      "tags": [
+        "web3-blockchain"
+      ],
+      "levels": [
+        "intermediate"
+      ],
+      "roles": [
+        "web3-engineer",
+        "software-engineer"
+      ],
+      "audiences": [
+        "Web3 / ブロックチェーン / スマートコントラクト開発を学びたい方向け"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Introduces Ethereum fundamentals, smart contracts, tooling, and hands-on exercises."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "composable-software-design-book",
+      "displayOrder": 42,
+      "title": {
+        "ja": "Compositional Software Design for Agentic Systems",
+        "en": "Compositional Software Design for Agentic Systems"
+      },
+      "officialEnglishTitle": "Compositional Software Design for Agentic Systems",
+      "status": "published",
+      "repo": "itdojp/composable-software-design-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/composable-software-design-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "related-independent",
+      "countedInMainLineup": false,
+      "category": "computer-science-theory",
+      "subcategory": "Computer Science & Theory / Independent English book",
+      "tags": [
+        "computer-science-theory",
+        "english",
+        "related-independent"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "software-engineer",
+        "architect"
+      ],
+      "audiences": [
+        "Intermediate+"
+      ],
+      "summary": {
+        "ja": "独立した英語書籍。日本語書籍 categorical-software-design-book の単純翻訳ではなく、関連書として扱う。",
+        "en": "English book focused on compositional software design for agentic systems, with its own scope, manuscript structure, and publication policy."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "en"
+      ],
+      "relatedEditions": [
+        "categorical-software-design-book"
+      ],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": 133,
+      "ux": {
+        "profile": null,
+        "modules": {}
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "関連する独立英語書籍。41冊の日本語メインライン冊数には含めない。",
+        "UX profile/modules は未割当。"
+      ],
+      "sourceRefs": [
+        "docs/en/index.md",
+        "README.md"
+      ]
+    },
+    {
+      "id": "infrastructure-monitoring-automation-guide",
+      "displayOrder": 1001,
+      "title": {
+        "ja": "インフラ監視・運用自動化実践ガイド",
+        "en": "インフラ監視・運用自動化実践ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "planned",
+      "repo": "itdojp/infrastructure-monitoring-automation-guide",
+      "repoVisibility": "not-created",
+      "pagesUrl": null,
+      "publicationScope": "planned",
+      "countingGroup": "planned",
+      "countedInMainLineup": false,
+      "category": "advanced-infra-practice",
+      "subcategory": "🔴 優先度: 高（必須追加 - 4冊）",
+      "tags": [
+        "planned",
+        "high",
+        "advanced-infra-practice"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "sre"
+      ],
+      "audiences": [
+        "中堅インフラエンジニア（経験3-8年）、SRE"
+      ],
+      "summary": {
+        "ja": "計画書籍。詳細は books/planned-books.md を参照。",
+        "en": ""
+      },
+      "prerequisites": [],
+      "estimatedWeeks": "6-8週間",
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "not-started",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": null,
+        "modules": {}
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "移行元の前提知識表記: Linux基礎、ネットワーク基礎"
+      ],
+      "sourceRefs": [
+        "books/planned-books.md",
+        "docs/en/index.md"
+      ]
+    },
+    {
+      "id": "enterprise-cloud-architecture-guide",
+      "displayOrder": 1002,
+      "title": {
+        "ja": "エンタープライズクラウドアーキテクチャ設計・運用",
+        "en": "エンタープライズクラウドアーキテクチャ設計・運用"
+      },
+      "officialEnglishTitle": null,
+      "status": "planned",
+      "repo": "itdojp/enterprise-cloud-architecture-guide",
+      "repoVisibility": "not-created",
+      "pagesUrl": null,
+      "publicationScope": "planned",
+      "countingGroup": "planned",
+      "countedInMainLineup": false,
+      "category": "applied-technologies",
+      "subcategory": "🔴 優先度: 高（必須追加 - 4冊）",
+      "tags": [
+        "planned",
+        "high",
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "sre"
+      ],
+      "audiences": [
+        "クラウドアーキテクト、シニアインフラエンジニア（経験6年以上）"
+      ],
+      "summary": {
+        "ja": "計画書籍。詳細は books/planned-books.md を参照。",
+        "en": ""
+      },
+      "prerequisites": [],
+      "estimatedWeeks": "8-10週間",
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "not-started",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": null,
+        "modules": {}
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "移行元の前提知識表記: cloud-infra-handbook、ネットワーク、セキュリティ基礎"
+      ],
+      "sourceRefs": [
+        "books/planned-books.md",
+        "docs/en/index.md"
+      ]
+    },
+    {
+      "id": "disaster-recovery-bcp-guide",
+      "displayOrder": 1003,
+      "title": {
+        "ja": "災害対策・事業継続計画（BCP）実装ガイド",
+        "en": "災害対策・事業継続計画（BCP）実装ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "planned",
+      "repo": "itdojp/disaster-recovery-bcp-guide",
+      "repoVisibility": "not-created",
+      "pagesUrl": null,
+      "publicationScope": "planned",
+      "countingGroup": "planned",
+      "countedInMainLineup": false,
+      "category": "advanced-infra-practice",
+      "subcategory": "🔴 優先度: 高（必須追加 - 4冊）",
+      "tags": [
+        "planned",
+        "high",
+        "advanced-infra-practice"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "sre"
+      ],
+      "audiences": [
+        "インフラ責任者、BCP担当者、上級エンジニア"
+      ],
+      "summary": {
+        "ja": "計画書籍。詳細は books/planned-books.md を参照。",
+        "en": ""
+      },
+      "prerequisites": [],
+      "estimatedWeeks": "6-8週間",
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "not-started",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": null,
+        "modules": {}
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "移行元の前提知識表記: インフラ全般、プロジェクト管理基礎"
+      ],
+      "sourceRefs": [
+        "books/planned-books.md",
+        "docs/en/index.md"
+      ]
+    },
+    {
+      "id": "practical-security-infrastructure-guide",
+      "displayOrder": 1004,
+      "title": {
+        "ja": "実践的セキュリティインフラ構築",
+        "en": "実践的セキュリティインフラ構築"
+      },
+      "officialEnglishTitle": null,
+      "status": "planned",
+      "repo": "itdojp/practical-security-infrastructure-guide",
+      "repoVisibility": "not-created",
+      "pagesUrl": null,
+      "publicationScope": "planned",
+      "countingGroup": "planned",
+      "countedInMainLineup": false,
+      "category": "security",
+      "subcategory": "🔴 優先度: 高（必須追加 - 4冊）",
+      "tags": [
+        "planned",
+        "high",
+        "security"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "security-engineer",
+        "infrastructure-engineer"
+      ],
+      "audiences": [
+        "セキュリティエンジニア、インフラエンジニア"
+      ],
+      "summary": {
+        "ja": "計画書籍。詳細は books/planned-books.md を参照。",
+        "en": ""
+      },
+      "prerequisites": [],
+      "estimatedWeeks": "8-10週間",
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "not-started",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": null,
+        "modules": {}
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "移行元の前提知識表記: ネットワーク、認証・認可基礎"
+      ],
+      "sourceRefs": [
+        "books/planned-books.md",
+        "docs/en/index.md"
+      ]
+    },
+    {
+      "id": "infrastructure-performance-capacity-planning",
+      "displayOrder": 1005,
+      "title": {
+        "ja": "インフラ性能管理・キャパシティプランニング",
+        "en": "インフラ性能管理・キャパシティプランニング"
+      },
+      "officialEnglishTitle": null,
+      "status": "planned",
+      "repo": "itdojp/infrastructure-performance-capacity-planning",
+      "repoVisibility": "not-created",
+      "pagesUrl": null,
+      "publicationScope": "planned",
+      "countingGroup": "planned",
+      "countedInMainLineup": false,
+      "category": "advanced-infra-practice",
+      "subcategory": "🟡 優先度: 中（価値向上 - 2冊）",
+      "tags": [
+        "planned",
+        "medium",
+        "advanced-infra-practice"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "sre"
+      ],
+      "audiences": [
+        "パフォーマンスエンジニア、SRE、上級インフラエンジニア"
+      ],
+      "summary": {
+        "ja": "計画書籍。詳細は books/planned-books.md を参照。",
+        "en": ""
+      },
+      "prerequisites": [],
+      "estimatedWeeks": "6-7週間",
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "not-started",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": null,
+        "modules": {}
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "移行元の前提知識表記: インフラ基礎、統計基礎"
+      ],
+      "sourceRefs": [
+        "books/planned-books.md",
+        "docs/en/index.md"
+      ]
+    },
+    {
+      "id": "compliance-infrastructure-guide",
+      "displayOrder": 1006,
+      "title": {
+        "ja": "コンプライアンス対応インフラ設計・運用",
+        "en": "コンプライアンス対応インフラ設計・運用"
+      },
+      "officialEnglishTitle": null,
+      "status": "planned",
+      "repo": "itdojp/compliance-infrastructure-guide",
+      "repoVisibility": "not-created",
+      "pagesUrl": null,
+      "publicationScope": "planned",
+      "countingGroup": "planned",
+      "countedInMainLineup": false,
+      "category": "security-governance",
+      "subcategory": "🟡 優先度: 中（価値向上 - 2冊）",
+      "tags": [
+        "planned",
+        "medium",
+        "security-governance"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "sre"
+      ],
+      "audiences": [
+        "企業インフラ責任者、監査対応担当者、コンプライアンス担当"
+      ],
+      "summary": {
+        "ja": "計画書籍。詳細は books/planned-books.md を参照。",
+        "en": ""
+      },
+      "prerequisites": [],
+      "estimatedWeeks": "5-7週間",
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "not-started",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": null,
+        "modules": {}
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "移行元の前提知識表記: セキュリティ基礎、法務基礎知識"
+      ],
+      "sourceRefs": [
+        "books/planned-books.md",
+        "docs/en/index.md"
+      ]
+    },
+    {
+      "id": "next-generation-infrastructure-guide",
+      "displayOrder": 1007,
+      "title": {
+        "ja": "次世代インフラ技術実践ガイド",
+        "en": "次世代インフラ技術実践ガイド"
+      },
+      "officialEnglishTitle": null,
+      "status": "planned",
+      "repo": "itdojp/next-generation-infrastructure-guide",
+      "repoVisibility": "not-created",
+      "pagesUrl": null,
+      "publicationScope": "planned",
+      "countingGroup": "planned",
+      "countedInMainLineup": false,
+      "category": "applied-technologies",
+      "subcategory": "🟢 優先度: 低（将来投資 - 1冊）",
+      "tags": [
+        "planned",
+        "low",
+        "applied-technologies"
+      ],
+      "levels": [
+        "intermediate",
+        "advanced"
+      ],
+      "roles": [
+        "infrastructure-engineer",
+        "sre"
+      ],
+      "audiences": [
+        "技術先端を追求するエンジニア、CTO、技術責任者"
+      ],
+      "summary": {
+        "ja": "計画書籍。詳細は books/planned-books.md を参照。",
+        "en": ""
+      },
+      "prerequisites": [],
+      "estimatedWeeks": "8-10週間",
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "not-started",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": null,
+        "modules": {}
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "移行元の前提知識表記: インフラ全般、AI/ML基礎"
+      ],
+      "sourceRefs": [
+        "books/planned-books.md",
+        "docs/en/index.md"
+      ]
+    }
+  ],
+  "learningPaths": [
+    {
+      "id": "beginner-linux",
+      "title": {
+        "ja": "IT未経験・Linux初学者",
+        "en": "Beginner Linux"
+      },
+      "description": {
+        "ja": "Linuxと基礎リテラシーから始める導入パス。",
+        "en": "Entry path for Linux and professional foundations."
+      },
+      "bookIds": [
+        "illustrated-linux-basics-book",
+        "wsl2-linux-essentials-book",
+        "evidence-based-engineering-book",
+        "issue-driven-work-book"
+      ],
+      "nextPathIds": [
+        "core-infrastructure"
+      ]
+    },
+    {
+      "id": "core-infrastructure",
+      "title": {
+        "ja": "インフラ基礎",
+        "en": "Core Infrastructure"
+      },
+      "description": {
+        "ja": "インフラ基礎から運用・クラウドへ進むパス。",
+        "en": "Core infrastructure path."
+      },
+      "bookIds": [
+        "linux-infra-textbook2",
+        "it-infra-software-essentials-book",
+        "IT-infra-book",
+        "IT-infra-troubleshooting-book",
+        "cloud-infra-book"
+      ],
+      "nextPathIds": [
+        "cloud-container",
+        "security"
+      ]
+    },
+    {
+      "id": "cloud-container",
+      "title": {
+        "ja": "クラウド／コンテナ",
+        "en": "Cloud and Containers"
+      },
+      "description": {
+        "ja": "クラウド、Kubernetes、コンテナの応用パス。",
+        "en": "Cloud, Kubernetes, and container path."
+      },
+      "bookIds": [
+        "cloud-infra-book",
+        "kubernetes-basics-book",
+        "kubernetes-cluster-ops-book",
+        "kubernetes-proxmox-to-cloud-book",
+        "podman-book"
+      ],
+      "nextPathIds": []
+    },
+    {
+      "id": "security",
+      "title": {
+        "ja": "セキュリティ／認証認可",
+        "en": "Security and Identity"
+      },
+      "description": {
+        "ja": "セキュリティ基礎、認証認可、ペネトレーションテストへ進むパス。",
+        "en": "Security and identity path."
+      },
+      "bookIds": [
+        "security-privacy-literacy-book",
+        "it-infra-security-guide-book",
+        "practical-auth-book",
+        "pentest-learning-book",
+        "incident-response-basics-book"
+      ],
+      "nextPathIds": []
+    },
+    {
+      "id": "ai-agentops",
+      "title": {
+        "ja": "AI支援開発／AgentOps",
+        "en": "AI-assisted Development and AgentOps"
+      },
+      "description": {
+        "ja": "AI時代の開発・運用・協働に進むパス。",
+        "en": "AI-assisted development and AgentOps path."
+      },
+      "bookIds": [
+        "ai-agent-engineering-book",
+        "GitHub-AgentOps-book",
+        "ai-agent-collaboration-book",
+        "ai-testing-strategy-book",
+        "github-workflow-book"
+      ],
+      "nextPathIds": []
+    },
+    {
+      "id": "theoretical-cs",
+      "title": {
+        "ja": "理論計算機科学",
+        "en": "Theoretical Computer Science"
+      },
+      "description": {
+        "ja": "理論計算機科学と合成的設計へ進むパス。",
+        "en": "Theoretical CS and compositional design path."
+      },
+      "bookIds": [
+        "theoretical-computer-science-prerequisites-book",
+        "theoretical-computer-science-textbook",
+        "categorical-software-design-book",
+        "composable-software-design-book"
+      ],
+      "nextPathIds": []
+    },
+    {
+      "id": "engineering-management",
+      "title": {
+        "ja": "エンジニアリングマネージャー／対人スキル",
+        "en": "Engineering Management and Communication"
+      },
+      "description": {
+        "ja": "コミュニケーション、交渉、思考法を扱うパス。",
+        "en": "Communication, negotiation, and thinking path."
+      },
+      "bookIds": [
+        "IT-engineer-communication-book",
+        "negotiation-for-engineers-book",
+        "ai-communication-book",
+        "LogicalThinking-AI-Era-Guide",
+        "ai-era-engineers-mind-book"
+      ],
+      "nextPathIds": []
+    }
+  ]
+}

--- a/docs/progress_report.md
+++ b/docs/progress_report.md
@@ -1,14 +1,14 @@
 # 📊 IT Engineer Knowledge Architecture 進捗レポート
 
-**更新日時**: 2026年07月10日 09:39:32 JST
+**更新日時**: 2026年07月10日 15:39:23 JST
 
 ## 📈 全体統計
 
 - **総書籍数**: 41冊
-- **アクティブ書籍**: 39冊
+- **アクティブ書籍**: 40冊
 - **アーカイブ書籍**: 0冊
 - **Private管理書籍**: 1冊
-- **利用不可**: 1冊
+- **利用不可**: 0冊
 - **総Open Issue数**: 6件
 - **総Open PR数**: 0件
 - **総Star数**: 1個
@@ -17,17 +17,12 @@
 
 | 書籍名 | Pages | Repo | ステータス | 最終更新 | Open Issues | Open PRs | Stars |
 |---|---|---|---|---|---:|---:|---:|
-| BioinformaticsGuide-book | [読む](https://itdojp.github.io/BioinformaticsGuide-book/) | [GitHub](https://github.com/itdojp/BioinformaticsGuide-book) | unavailable | N/A | 0 | 0 | 0 |
-| GitHub-AgentOps-book | [読む](https://itdojp.github.io/GitHub-AgentOps-book/) | [GitHub](https://github.com/itdojp/GitHub-AgentOps-book) | active | 2026-06-26T23:08:47Z | 0 | 0 | 0 |
-| IT-engineer-communication-book | [読む](https://itdojp.github.io/IT-engineer-communication-book/) | [GitHub](https://github.com/itdojp/IT-engineer-communication-book) | active | 2026-06-26T23:08:47Z | 0 | 0 | 0 |
-| IT-infra-book | [読む](https://itdojp.github.io/IT-infra-book/) | [GitHub](https://github.com/itdojp/IT-infra-book) | active | 2026-06-26T23:45:08Z | 0 | 0 | 0 |
-| IT-infra-troubleshooting-book | [読む](https://itdojp.github.io/IT-infra-troubleshooting-book/) | [GitHub](https://github.com/itdojp/IT-infra-troubleshooting-book) | active | 2026-06-26T23:26:37Z | 0 | 0 | 0 |
-| LogicalThinking-AI-Era-Guide | [読む](https://itdojp.github.io/LogicalThinking-AI-Era-Guide/) | [GitHub](https://github.com/itdojp/LogicalThinking-AI-Era-Guide) | active | 2026-06-26T23:45:08Z | 0 | 0 | 0 |
-| ai-agent-collaboration-book | [読む（無料公開範囲）](https://itdojp.github.io/ai-agent-collaboration-book/) | 有料部分を含むため管理リポジトリは Private。 | private | N/A | 0 | 0 | 0 |
+| ai-agent-collaboration-book | [読む（無料公開範囲）](https://itdojp.github.io/ai-agent-collaboration-book/) | 有料部分を含むPrivate管理書籍。 | private | N/A | 0 | 0 | 0 |
 | ai-agent-engineering-book | [読む](https://itdojp.github.io/ai-agent-engineering-book/) | [GitHub](https://github.com/itdojp/ai-agent-engineering-book) | active | 2026-06-27T05:17:36Z | 0 | 0 | 0 |
 | ai-communication-book | [読む](https://itdojp.github.io/ai-communication-book/) | [GitHub](https://github.com/itdojp/ai-communication-book) | active | 2026-06-28T04:03:12Z | 1 | 0 | 0 |
 | ai-era-engineers-mind-book | [読む](https://itdojp.github.io/ai-era-engineers-mind-book/) | [GitHub](https://github.com/itdojp/ai-era-engineers-mind-book) | active | 2026-06-27T03:13:49Z | 0 | 0 | 0 |
 | ai-testing-strategy-book | [読む](https://itdojp.github.io/ai-testing-strategy-book/) | [GitHub](https://github.com/itdojp/ai-testing-strategy-book) | active | 2026-06-27T00:00:57Z | 0 | 0 | 0 |
+| BioinformaticsGuide-book | [読む](https://itdojp.github.io/BioinformaticsGuide-book/) | [GitHub](https://github.com/itdojp/BioinformaticsGuide-book) | active | 2026-06-27T05:17:33Z | 0 | 0 | 0 |
 | categorical-software-design-book | [読む](https://itdojp.github.io/categorical-software-design-book/) | [GitHub](https://github.com/itdojp/categorical-software-design-book) | active | 2026-06-27T05:39:19Z | 0 | 0 | 0 |
 | cloud-infra-book | [読む](https://itdojp.github.io/cloud-infra-book/) | [GitHub](https://github.com/itdojp/cloud-infra-book) | active | 2026-06-27T00:00:56Z | 0 | 0 | 0 |
 | computational-physicalism-book | [読む](https://itdojp.github.io/computational-physicalism-book/) | [GitHub](https://github.com/itdojp/computational-physicalism-book) | active | 2026-06-27T05:03:19Z | 0 | 0 | 0 |
@@ -36,17 +31,22 @@
 | ethereum-learning-bootcamp | [読む](https://itdojp.github.io/ethereum-learning-bootcamp/) | [GitHub](https://github.com/itdojp/ethereum-learning-bootcamp) | active | 2026-06-27T00:26:19Z | 0 | 0 | 0 |
 | evidence-based-engineering-book | [読む](https://itdojp.github.io/evidence-based-engineering-book/) | [GitHub](https://github.com/itdojp/evidence-based-engineering-book) | active | 2026-06-26T23:26:37Z | 0 | 0 | 0 |
 | formal-methods-book | [読む](https://itdojp.github.io/formal-methods-book/) | [GitHub](https://github.com/itdojp/formal-methods-book) | active | 2026-06-27T00:55:33Z | 0 | 0 | 1 |
+| GitHub-AgentOps-book | [読む](https://itdojp.github.io/GitHub-AgentOps-book/) | [GitHub](https://github.com/itdojp/GitHub-AgentOps-book) | active | 2026-06-26T23:08:47Z | 0 | 0 | 0 |
 | github-guide-for-beginners-book | [読む](https://itdojp.github.io/github-guide-for-beginners-book/) | [GitHub](https://github.com/itdojp/github-guide-for-beginners-book) | active | 2026-06-27T00:26:23Z | 0 | 0 | 0 |
 | github-workflow-book | [読む](https://itdojp.github.io/github-workflow-book/) | [GitHub](https://github.com/itdojp/github-workflow-book) | active | 2026-06-27T03:50:29Z | 0 | 0 | 0 |
 | illustrated-linux-basics-book | [読む](https://itdojp.github.io/illustrated-linux-basics-book/) | [GitHub](https://github.com/itdojp/illustrated-linux-basics-book) | active | 2026-06-27T04:14:03Z | 0 | 0 | 0 |
 | incident-response-basics-book | [読む](https://itdojp.github.io/incident-response-basics-book/) | [GitHub](https://github.com/itdojp/incident-response-basics-book) | active | 2026-06-27T00:55:36Z | 0 | 0 | 0 |
 | issue-driven-work-book | [読む](https://itdojp.github.io/issue-driven-work-book/) | [GitHub](https://github.com/itdojp/issue-driven-work-book) | active | 2026-06-27T02:42:30Z | 0 | 0 | 0 |
+| IT-engineer-communication-book | [読む](https://itdojp.github.io/IT-engineer-communication-book/) | [GitHub](https://github.com/itdojp/IT-engineer-communication-book) | active | 2026-06-26T23:08:47Z | 0 | 0 | 0 |
+| IT-infra-book | [読む](https://itdojp.github.io/IT-infra-book/) | [GitHub](https://github.com/itdojp/IT-infra-book) | active | 2026-06-26T23:45:08Z | 0 | 0 | 0 |
 | it-infra-security-guide-book | [読む](https://itdojp.github.io/it-infra-security-guide-book/) | [GitHub](https://github.com/itdojp/it-infra-security-guide-book) | active | 2026-06-27T01:27:47Z | 0 | 0 | 0 |
 | it-infra-software-essentials-book | [読む](https://itdojp.github.io/it-infra-software-essentials-book/) | [GitHub](https://github.com/itdojp/it-infra-software-essentials-book) | active | 2026-06-27T03:13:50Z | 0 | 0 | 0 |
+| IT-infra-troubleshooting-book | [読む](https://itdojp.github.io/IT-infra-troubleshooting-book/) | [GitHub](https://github.com/itdojp/IT-infra-troubleshooting-book) | active | 2026-06-26T23:26:37Z | 0 | 0 | 0 |
 | kubernetes-basics-book | [読む](https://itdojp.github.io/kubernetes-basics-book/) | [GitHub](https://github.com/itdojp/kubernetes-basics-book) | active | 2026-06-27T05:53:59Z | 1 | 0 | 0 |
 | kubernetes-cluster-ops-book | [読む](https://itdojp.github.io/kubernetes-cluster-ops-book/) | [GitHub](https://github.com/itdojp/kubernetes-cluster-ops-book) | active | 2026-06-27T06:05:30Z | 1 | 0 | 0 |
 | kubernetes-proxmox-to-cloud-book | [読む](https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/) | [GitHub](https://github.com/itdojp/kubernetes-proxmox-to-cloud-book) | active | 2026-06-27T07:30:34Z | 1 | 0 | 0 |
 | linux-infra-textbook2 | [読む](https://itdojp.github.io/linux-infra-textbook2/) | [GitHub](https://github.com/itdojp/linux-infra-textbook2) | active | 2026-06-27T01:27:48Z | 0 | 0 | 0 |
+| LogicalThinking-AI-Era-Guide | [読む](https://itdojp.github.io/LogicalThinking-AI-Era-Guide/) | [GitHub](https://github.com/itdojp/LogicalThinking-AI-Era-Guide) | active | 2026-06-26T23:45:08Z | 0 | 0 | 0 |
 | negotiation-for-engineers-book | [読む](https://itdojp.github.io/negotiation-for-engineers-book/) | [GitHub](https://github.com/itdojp/negotiation-for-engineers-book) | active | 2026-06-27T01:45:56Z | 0 | 0 | 0 |
 | pentest-learning-book | [読む](https://itdojp.github.io/pentest-learning-book/) | [GitHub](https://github.com/itdojp/pentest-learning-book) | active | 2026-06-27T04:14:06Z | 0 | 0 | 0 |
 | podman-book | [読む](https://itdojp.github.io/podman-book/) | [GitHub](https://github.com/itdojp/podman-book) | active | 2026-06-27T06:12:34Z | 1 | 0 | 0 |
@@ -61,4 +61,4 @@
 
 備考: `linux-infra-textbook` は `linux-infra-textbook2` に置換済みの旧版（アーカイブ）
 
-生成元: `docs/publishing/book-registry.json`
+生成元: `docs/_data/catalog.json`

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -1,6 +1,7 @@
 {
-  "schemaVersion": "1.0",
-  "updatedAt": "2026-07-04",
+  "schemaVersion": "1.0.0",
+  "updatedAt": "2026-07-10",
+  "generatedFrom": "docs/_data/catalog.json",
   "modulesCatalog": [
     "quickStart",
     "readingGuide",
@@ -12,102 +13,6 @@
     "glossary"
   ],
   "books": {
-    "BioinformaticsGuide-book": {
-      "repo": "itdojp/BioinformaticsGuide-book",
-      "pages": "https://itdojp.github.io/BioinformaticsGuide-book/",
-      "profile": "B",
-      "modules": {
-        "quickStart": false,
-        "readingGuide": false,
-        "checklistPack": true,
-        "troubleshootingFlow": true,
-        "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
-        "glossary": false
-      },
-      "notes": "暫定割当（要確認）"
-    },
-    "GitHub-AgentOps-book": {
-      "repo": "itdojp/GitHub-AgentOps-book",
-      "pages": "https://itdojp.github.io/GitHub-AgentOps-book/",
-      "profile": "B",
-      "modules": {
-        "quickStart": false,
-        "readingGuide": false,
-        "checklistPack": true,
-        "troubleshootingFlow": true,
-        "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
-        "glossary": false
-      },
-      "notes": "暫定割当（要確認）"
-    },
-    "IT-engineer-communication-book": {
-      "repo": "itdojp/IT-engineer-communication-book",
-      "pages": "https://itdojp.github.io/IT-engineer-communication-book/",
-      "profile": "B",
-      "modules": {
-        "quickStart": false,
-        "readingGuide": false,
-        "checklistPack": true,
-        "troubleshootingFlow": true,
-        "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
-        "glossary": false
-      },
-      "notes": "暫定割当（要確認）"
-    },
-    "IT-infra-book": {
-      "repo": "itdojp/IT-infra-book",
-      "pages": "https://itdojp.github.io/IT-infra-book/",
-      "profile": "B",
-      "modules": {
-        "quickStart": false,
-        "readingGuide": false,
-        "checklistPack": true,
-        "troubleshootingFlow": true,
-        "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
-        "glossary": false
-      },
-      "notes": "暫定割当（要確認）"
-    },
-    "IT-infra-troubleshooting-book": {
-      "repo": "itdojp/IT-infra-troubleshooting-book",
-      "pages": "https://itdojp.github.io/IT-infra-troubleshooting-book/",
-      "profile": "B",
-      "modules": {
-        "quickStart": false,
-        "readingGuide": false,
-        "checklistPack": true,
-        "troubleshootingFlow": true,
-        "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
-        "glossary": false
-      },
-      "notes": "暫定割当（要確認）"
-    },
-    "LogicalThinking-AI-Era-Guide": {
-      "repo": "itdojp/LogicalThinking-AI-Era-Guide",
-      "pages": "https://itdojp.github.io/LogicalThinking-AI-Era-Guide/",
-      "profile": "C",
-      "modules": {
-        "quickStart": false,
-        "readingGuide": true,
-        "checklistPack": false,
-        "troubleshootingFlow": false,
-        "conceptMap": true,
-        "figureIndex": true,
-        "legalNotice": false,
-        "glossary": true
-      },
-      "notes": "暫定割当（要確認）"
-    },
     "ai-agent-collaboration-book": {
       "repo": "itdojp/ai-agent-collaboration-book",
       "pages": "https://itdojp.github.io/ai-agent-collaboration-book/",
@@ -122,11 +27,11 @@
         "legalNotice": true,
         "glossary": true
       },
-      "notes": "AIエージェントを業務成果へ接続する依頼・文脈・委任・検証・権限・判断・組織展開の横断書籍。無料公開範囲と有料版を分けて運用する。",
+      "notes": "AIエージェントを業務成果へ接続する依頼・文脈・委任・検証・権限・判断・組織展開の横断書籍。無料公開範囲と有料版を分けて運用する。 / 有料部分を含むPrivate管理書籍。Pagesは無料公開範囲のみ。",
       "repoVisibility": "private",
       "publicationModel": "free-preview-and-paid-edition",
       "pagesPublicationScope": "free-preview-aligned-with-zenn-free-scope",
-      "accessNote": "有料部分を含むため管理リポジトリは Private。GitHub Pages は Zenn 等で無料公開する範囲に準じた試読範囲のみを公開する方針。"
+      "accessNote": "有料部分を含むPrivate管理書籍。Pagesは無料公開範囲のみ。"
     },
     "ai-agent-engineering-book": {
       "repo": "itdojp/ai-agent-engineering-book",
@@ -142,7 +47,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "暫定割当（要確認）/ 英語版あり"
+      "notes": "暫定割当（要確認）/ 英語版あり / 同一書籍内に英語版ページあり。"
     },
     "ai-communication-book": {
       "repo": "itdojp/ai-communication-book",
@@ -192,6 +97,22 @@
       },
       "notes": "暫定割当（要確認）"
     },
+    "BioinformaticsGuide-book": {
+      "repo": "itdojp/BioinformaticsGuide-book",
+      "pages": "https://itdojp.github.io/BioinformaticsGuide-book/",
+      "profile": "B",
+      "modules": {
+        "quickStart": false,
+        "readingGuide": false,
+        "checklistPack": true,
+        "troubleshootingFlow": true,
+        "conceptMap": false,
+        "figureIndex": true,
+        "legalNotice": false,
+        "glossary": false
+      },
+      "notes": "暫定割当（要確認）"
+    },
     "categorical-software-design-book": {
       "repo": "itdojp/categorical-software-design-book",
       "pages": "https://itdojp.github.io/categorical-software-design-book/",
@@ -206,7 +127,7 @@
         "legalNotice": true,
         "glossary": true
       },
-      "notes": "Profile C の暫定割当。付録Dは図版・レビュー前の最小確認項目・症状別再参照の入口として扱う。raw サンプルは本文より先に更新される場合があるため要確認。"
+      "notes": "Profile C の暫定割当。付録Dは図版・レビュー前の最小確認項目・症状別再参照の入口として扱う。raw サンプルは本文より先に更新される場合があるため要確認。 / 独立英語書籍 composable-software-design-book と関連。単純翻訳・旧新版関係ではない。"
     },
     "cloud-infra-book": {
       "repo": "itdojp/cloud-infra-book",
@@ -320,6 +241,22 @@
       },
       "notes": "暫定割当（要確認）"
     },
+    "GitHub-AgentOps-book": {
+      "repo": "itdojp/GitHub-AgentOps-book",
+      "pages": "https://itdojp.github.io/GitHub-AgentOps-book/",
+      "profile": "B",
+      "modules": {
+        "quickStart": false,
+        "readingGuide": false,
+        "checklistPack": true,
+        "troubleshootingFlow": true,
+        "conceptMap": false,
+        "figureIndex": true,
+        "legalNotice": false,
+        "glossary": false
+      },
+      "notes": "暫定割当（要確認）"
+    },
     "github-guide-for-beginners-book": {
       "repo": "itdojp/github-guide-for-beginners-book",
       "pages": "https://itdojp.github.io/github-guide-for-beginners-book/",
@@ -400,6 +337,38 @@
       },
       "notes": "暫定割当（要確認）"
     },
+    "IT-engineer-communication-book": {
+      "repo": "itdojp/IT-engineer-communication-book",
+      "pages": "https://itdojp.github.io/IT-engineer-communication-book/",
+      "profile": "B",
+      "modules": {
+        "quickStart": false,
+        "readingGuide": false,
+        "checklistPack": true,
+        "troubleshootingFlow": true,
+        "conceptMap": false,
+        "figureIndex": true,
+        "legalNotice": false,
+        "glossary": false
+      },
+      "notes": "暫定割当（要確認）"
+    },
+    "IT-infra-book": {
+      "repo": "itdojp/IT-infra-book",
+      "pages": "https://itdojp.github.io/IT-infra-book/",
+      "profile": "B",
+      "modules": {
+        "quickStart": false,
+        "readingGuide": false,
+        "checklistPack": true,
+        "troubleshootingFlow": true,
+        "conceptMap": false,
+        "figureIndex": true,
+        "legalNotice": false,
+        "glossary": false
+      },
+      "notes": "暫定割当（要確認）"
+    },
     "it-infra-security-guide-book": {
       "repo": "itdojp/it-infra-security-guide-book",
       "pages": "https://itdojp.github.io/it-infra-security-guide-book/",
@@ -419,6 +388,22 @@
     "it-infra-software-essentials-book": {
       "repo": "itdojp/it-infra-software-essentials-book",
       "pages": "https://itdojp.github.io/it-infra-software-essentials-book/",
+      "profile": "B",
+      "modules": {
+        "quickStart": false,
+        "readingGuide": false,
+        "checklistPack": true,
+        "troubleshootingFlow": true,
+        "conceptMap": false,
+        "figureIndex": true,
+        "legalNotice": false,
+        "glossary": false
+      },
+      "notes": "暫定割当（要確認）"
+    },
+    "IT-infra-troubleshooting-book": {
+      "repo": "itdojp/IT-infra-troubleshooting-book",
+      "pages": "https://itdojp.github.io/IT-infra-troubleshooting-book/",
       "profile": "B",
       "modules": {
         "quickStart": false,
@@ -495,6 +480,22 @@
         "glossary": false
       },
       "notes": "linux-infra-textbook を置換（旧版はアーカイブ）"
+    },
+    "LogicalThinking-AI-Era-Guide": {
+      "repo": "itdojp/LogicalThinking-AI-Era-Guide",
+      "pages": "https://itdojp.github.io/LogicalThinking-AI-Era-Guide/",
+      "profile": "C",
+      "modules": {
+        "quickStart": false,
+        "readingGuide": true,
+        "checklistPack": false,
+        "troubleshootingFlow": false,
+        "conceptMap": true,
+        "figureIndex": true,
+        "legalNotice": false,
+        "glossary": true
+      },
+      "notes": "暫定割当（要確認）"
     },
     "negotiation-for-engineers-book": {
       "repo": "itdojp/negotiation-for-engineers-book",

--- a/docs/publishing/catalog-migration-report.md
+++ b/docs/publishing/catalog-migration-report.md
@@ -1,0 +1,106 @@
+# Catalog Migration Report
+
+作成日: 2026-07-10
+対象Issue: [#176](https://github.com/itdojp/it-engineer-knowledge-architecture/issues/176)
+
+## 目的
+
+書籍横断メタデータの正本を `docs/_data/catalog.json` に集約し、既存の重複ファイルに含まれる不一致を隠さず記録する。PR 1/2 の範囲では公開サイトのデザインと既存URLは変更せず、既存の互換利用箇所には正本から生成した `docs/publishing/book-registry.json` を提供する。
+
+## 移行元
+
+次のファイルを移行・照合対象にした。
+
+- `README.md`
+- `docs/index.md`
+- `docs/en/index.md`
+- `books/existing-books.md`
+- `books/planned-books.md`
+- `roadmap/learning-paths.md`
+- `docs/publishing/book-registry.json`
+
+GitHub API由来のStar数、Open Issue数、Open PR数、リポジトリ更新日時は正本に保存しない。これらは既存の進捗レポート生成時に動的フィールドとして扱う。
+
+## 移行結果
+
+| 区分 | 件数 | 正本上の表現 |
+|---|---:|---|
+| メインライン公開書籍 | 41 | `countingGroup: "main-lineup"` かつ `countedInMainLineup: true` |
+| 計画書籍 | 7 | `status: "planned"`, `countingGroup: "planned"`, `publicationScope: "planned"` |
+| 関連する独立英語書籍 | 1 | `countingGroup: "related-independent"`, `countedInMainLineup: false` |
+| 総レコード | 49 | 上記すべてを `books[]` に含める |
+| 互換用registry出力 | 41 | 既存互換のためメインライン公開書籍のみを `books` に出力 |
+
+`docs/publishing/book-registry.json` は `docs/_data/catalog.json` から生成する互換ファイルに変更した。今後、新規メタデータ項目は原則として正本へ追加し、registryは既存Workflow/ツールの互換用途に限定する。
+
+## 正本化で明示した例外・方針
+
+### 関連する独立英語書籍
+
+`composable-software-design-book` は `docs/en/index.md` で `Independent EN book` として扱われている。日本語メインライン41冊には含めず、正本では次のように明示した。
+
+- `countingGroup: "related-independent"`
+- `countedInMainLineup: false`
+- `languages: ["en"]`
+- 関連日本語書籍 `categorical-software-design-book` とは `relatedEditions` で相互参照
+
+### Private管理書籍
+
+`ai-agent-collaboration-book` は有料部分を含むため管理リポジトリがPrivateである。正本では次のように明示した。
+
+- `repoVisibility: "private"`
+- `publicationScope: "free-preview"`
+- `pagesUrl` は無料公開範囲を示す公開Pages URLを保持
+- `notes` に「有料部分を含むPrivate管理書籍。Pagesは無料公開範囲のみ。」を記録
+
+互換registryにも `repoVisibility`, `pagesPublicationScope`, `accessNote` を生成する。
+
+### 計画書籍
+
+計画7冊は、公開済みと同じスキーマに載せたうえで、未作成状態を構造化した。
+
+- `status: "planned"`
+- `repoVisibility: "not-created"`
+- `pagesUrl: null`
+- `publicationScope: "planned"`
+
+リポジトリ名は計画上の識別子として保持するが、存在確認やPages公開確認の対象にはしない。
+
+## 確認済みの不一致・未解決事項
+
+| 項目 | 内容 | 対応 |
+|---|---|---|
+| `books/existing-books.md` の旧情報 | `cloud-infra-handbook` など、現行公開カタログ/registryと異なる旧リポジトリ名・URLが残っている。 | 正本は現在の公開カタログと既存registryを優先し、旧情報は本レポートで未解決として記録。Phase 4/5以降で既存重複ページを正本生成へ移行する。 |
+| レビュー状態の粒度差 | `README.md` は「既存41冊（レビュー済み）」、一方 `books/existing-books.md` には「レビュー予定」や古いIssue参照が残る。 | メインライン公開書籍は `reviewStatus: "reviewed"` を基本にしたが、個別の `lastReviewedAt` / `reviewIssue` は推測せず `null` のままにした。 |
+| 個別日本語概要 | README公開カタログの多くは個別の日本語要約を持たない。 | `summary.ja` は推測で埋めず空文字を許容し、各レコードの `notes` に「日本語個別概要はREADME公開カタログ上で未記載。」を記録した。 |
+| UX profile/modules | 既存 `docs/publishing/book-registry.json` に「暫定割当（要確認）」が含まれる。 | `ux.profile` / `ux.modules` に構造化して移行し、暫定性は `notes` に残した。 |
+| 動的メトリクス | Star数、Open Issue数、Open PR数、GitHub上の更新日時は時点依存。 | 正本に保存せず、`sourcePolicy.externalDynamicFields` と進捗レポート生成スクリプトで扱う。 |
+| 学習順序 | `roadmap/learning-paths.md` は表示名・本文説明ベースで、機械検証可能なID参照ではない。 | 初期正本では `learningPaths[].bookIds` と `nextPathIds` をcatalog IDで構造化した。今後、公開表示は正本生成へ移行する。 |
+
+## 構造化できた暫定事項
+
+- `ux.profile` と `ux.modules` は既存registryの値を保持し、未確認性を `notes` に残した。
+- `publicationScope` により、完全公開、無料公開範囲、計画段階を区別した。
+- `countingGroup` と `countedInMainLineup` により、41冊メインライン、7冊計画、1冊関連独立書籍の集計意味を分離した。
+- `repoVisibility` により、公開、Private管理、未作成を区別した。
+- `prerequisites`, `recommendedAfter`, `relatedEditions`, `learningPaths[].bookIds`, `learningPaths[].nextPathIds` は表示名ではなくcatalog IDで参照するようにした。
+
+## 検証基盤への接続
+
+この移行に合わせて、次の検証を追加した。
+
+- `scripts/validate-catalog.mjs`: 必須フィールド、enum、ID/repo/Pages URL一意性、公開/計画/Private管理書籍の整合、参照先ID、集計値を検証
+- `scripts/validate-learning-graph.mjs`: 前提関係と学習パスの循環を検出
+- `scripts/generate-catalog-derived.mjs --check`: 正本から生成した互換registryとの差分を検出
+- `scripts/test-catalog-fixtures.mjs`: 正常fixtureと不正fixture（ID重複、存在しない前提ID、循環、Private管理書籍の公開範囲不整合）を検証
+- `.github/workflows/validate-learning-paths.yml`: grep中心の冊数確認と空実装の循環/前提チェックを `npm run verify` ベースの実検証へ置換
+
+## このPRで意図的に変更しない範囲
+
+- 公開サイトのレイアウト、デザイン、URL、アンカー
+- `README.md`, `docs/index.md`, `docs/en/index.md` のデータ駆動生成
+- `books/existing-books.md` や `books/planned-books.md` の削除・再生成
+- 個別書籍リポジトリの修正
+- 外部URLのHTTP確認をPR必須チェックに含めること
+
+これらは #176 の後続Phaseで扱う。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "it-engineer-knowledge-architecture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "it-engineer-knowledge-architecture",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "it-engineer-knowledge-architecture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Catalog and publishing governance for the IT Engineer Knowledge Architecture book lineup",
+  "scripts": {
+    "generate": "node scripts/generate-catalog-derived.mjs",
+    "check:generated": "node scripts/generate-catalog-derived.mjs --check",
+    "validate:catalog": "node scripts/validate-catalog.mjs",
+    "validate:learning-graph": "node scripts/validate-learning-graph.mjs",
+    "test:fixtures": "node scripts/test-catalog-fixtures.mjs",
+    "verify": "npm run validate:catalog && npm run validate:learning-graph && npm run check:generated && npm run test:fixtures"
+  }
+}

--- a/schemas/catalog.schema.json
+++ b/schemas/catalog.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://itdojp.github.io/it-engineer-knowledge-architecture/schemas/catalog.schema.json",
+  "title": "IT Engineer Knowledge Architecture Catalog",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "updatedAt",
+    "sourcePolicy",
+    "expectedCounts",
+    "moduleCatalog",
+    "books",
+    "learningPaths"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "type": "string" },
+    "updatedAt": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+    "sourcePolicy": {
+      "type": "object",
+      "required": ["canonical", "derivedFiles", "externalDynamicFields", "notes"],
+      "additionalProperties": false,
+      "properties": {
+        "canonical": { "const": "docs/_data/catalog.json" },
+        "derivedFiles": { "type": "array", "items": { "type": "string" } },
+        "externalDynamicFields": { "type": "array", "items": { "type": "string" } },
+        "notes": { "type": "string" }
+      }
+    },
+    "expectedCounts": {
+      "type": "object",
+      "required": ["mainLineup", "planned", "relatedIndependent"],
+      "additionalProperties": false,
+      "properties": {
+        "mainLineup": { "type": "integer", "minimum": 0 },
+        "planned": { "type": "integer", "minimum": 0 },
+        "relatedIndependent": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "moduleCatalog": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "books": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/book" }
+    },
+    "learningPaths": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/learningPath" }
+    }
+  },
+  "$defs": {
+    "localizedTitle": {
+      "type": "object",
+      "required": ["ja", "en"],
+      "additionalProperties": false,
+      "properties": {
+        "ja": { "type": "string" },
+        "en": { "type": "string" }
+      }
+    },
+    "localizedSummary": {
+      "type": "object",
+      "required": ["ja", "en"],
+      "additionalProperties": false,
+      "properties": {
+        "ja": { "type": "string" },
+        "en": { "type": "string" }
+      }
+    },
+    "ux": {
+      "type": "object",
+      "required": ["profile", "modules"],
+      "additionalProperties": false,
+      "properties": {
+        "profile": { "type": ["string", "null"], "enum": ["A", "B", "C", null] },
+        "modules": {
+          "type": "object",
+          "additionalProperties": { "type": "boolean" }
+        }
+      }
+    },
+    "book": {
+      "type": "object",
+      "required": [
+        "id",
+        "displayOrder",
+        "title",
+        "officialEnglishTitle",
+        "status",
+        "repo",
+        "repoVisibility",
+        "pagesUrl",
+        "publicationScope",
+        "countingGroup",
+        "countedInMainLineup",
+        "category",
+        "subcategory",
+        "tags",
+        "levels",
+        "roles",
+        "audiences",
+        "summary",
+        "prerequisites",
+        "estimatedWeeks",
+        "recommendedAfter",
+        "languages",
+        "relatedEditions",
+        "reviewStatus",
+        "lastReviewedAt",
+        "reviewIssue",
+        "ux",
+        "addedAt",
+        "updatedAt",
+        "notes",
+        "sourceRefs"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+$" },
+        "displayOrder": { "type": "number" },
+        "title": { "$ref": "#/$defs/localizedTitle" },
+        "officialEnglishTitle": { "type": ["string", "null"] },
+        "status": { "type": "string", "enum": ["published", "planned", "archived"] },
+        "repo": { "type": ["string", "null"], "pattern": "^itdojp/[A-Za-z0-9_.-]+$" },
+        "repoVisibility": { "type": "string", "enum": ["public", "private", "not-created"] },
+        "pagesUrl": { "type": ["string", "null"], "pattern": "^https://itdojp\\.github\\.io/[A-Za-z0-9_.-]+/$" },
+        "publicationScope": { "type": "string", "enum": ["full-public", "free-preview", "planned"] },
+        "countingGroup": { "type": "string", "enum": ["main-lineup", "planned", "related-independent", "archive"] },
+        "countedInMainLineup": { "type": "boolean" },
+        "category": { "type": "string" },
+        "subcategory": { "type": "string" },
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "levels": { "type": "array", "items": { "type": "string" } },
+        "roles": { "type": "array", "items": { "type": "string" } },
+        "audiences": { "type": "array", "items": { "type": "string" } },
+        "summary": { "$ref": "#/$defs/localizedSummary" },
+        "prerequisites": { "type": "array", "items": { "type": "string" } },
+        "estimatedWeeks": { "type": ["string", "number", "null"] },
+        "recommendedAfter": { "type": "array", "items": { "type": "string" } },
+        "languages": { "type": "array", "items": { "type": "string", "enum": ["ja", "en"] }, "minItems": 1 },
+        "relatedEditions": { "type": "array", "items": { "type": "string" } },
+        "reviewStatus": { "type": "string", "enum": ["reviewed", "review-needed", "not-started", "unknown"] },
+        "lastReviewedAt": { "type": ["string", "null"], "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+        "reviewIssue": { "type": ["integer", "null"], "minimum": 1 },
+        "ux": { "$ref": "#/$defs/ux" },
+        "addedAt": { "type": ["string", "null"], "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+        "updatedAt": { "type": ["string", "null"], "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+        "notes": { "type": "array", "items": { "type": "string" } },
+        "sourceRefs": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      }
+    },
+    "learningPath": {
+      "type": "object",
+      "required": ["id", "title", "description", "bookIds", "nextPathIds"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+        "title": { "$ref": "#/$defs/localizedTitle" },
+        "description": { "$ref": "#/$defs/localizedSummary" },
+        "bookIds": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "nextPathIds": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/scripts/catalog-utils.mjs
+++ b/scripts/catalog-utils.mjs
@@ -1,0 +1,319 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const DEFAULT_CATALOG_PATH = path.join(ROOT, 'docs', '_data', 'catalog.json');
+export const DEFAULT_REGISTRY_PATH = path.join(ROOT, 'docs', 'publishing', 'book-registry.json');
+
+export function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+export function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export function loadCatalog(filePath = DEFAULT_CATALOG_PATH) {
+  return readJson(filePath);
+}
+
+const allowedProfiles = new Set(['A', 'B', 'C', null]);
+const allowedBookStatus = new Set(['published', 'planned', 'archived']);
+const allowedRepoVisibility = new Set(['public', 'private', 'not-created']);
+const allowedPublicationScope = new Set(['full-public', 'free-preview', 'planned']);
+const allowedCountingGroup = new Set(['main-lineup', 'planned', 'related-independent', 'archive']);
+const allowedReviewStatus = new Set(['reviewed', 'review-needed', 'not-started', 'unknown']);
+const allowedLanguages = new Set(['ja', 'en']);
+const requiredBookFields = [
+  'id', 'displayOrder', 'title', 'officialEnglishTitle', 'status', 'repo', 'repoVisibility',
+  'pagesUrl', 'publicationScope', 'countingGroup', 'countedInMainLineup', 'category',
+  'subcategory', 'tags', 'levels', 'roles', 'audiences', 'summary', 'prerequisites',
+  'estimatedWeeks', 'recommendedAfter', 'languages', 'relatedEditions', 'reviewStatus',
+  'lastReviewedAt', 'reviewIssue', 'ux', 'addedAt', 'updatedAt', 'notes', 'sourceRefs'
+];
+const dateRe = /^\d{4}-\d{2}-\d{2}$/;
+const repoRe = /^itdojp\/[A-Za-z0-9_.-]+$/;
+const pagesRe = /^https:\/\/itdojp\.github\.io\/[A-Za-z0-9_.-]+\/$/;
+const idRe = /^[A-Za-z0-9_.-]+$/;
+
+function isObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireArray(errors, value, label) {
+  if (!Array.isArray(value)) {
+    errors.push(`${label} must be an array`);
+    return [];
+  }
+  return value;
+}
+
+function requireStringArray(errors, value, label, { minItems = 0 } = {}) {
+  const items = requireArray(errors, value, label);
+  if (items.length < minItems) errors.push(`${label} must contain at least ${minItems} item(s)`);
+  for (const [index, item] of items.entries()) {
+    if (typeof item !== 'string') errors.push(`${label}[${index}] must be a string`);
+  }
+  return items;
+}
+
+function requireString(errors, value, label, { allowEmpty = true } = {}) {
+  if (typeof value !== 'string' || (!allowEmpty && value.length === 0)) {
+    errors.push(`${label} must be a string`);
+  }
+}
+
+export function validateCatalog(catalog) {
+  const errors = [];
+  if (!isObject(catalog)) {
+    return ['catalog root must be an object'];
+  }
+  for (const key of ['schemaVersion', 'updatedAt', 'sourcePolicy', 'expectedCounts', 'moduleCatalog', 'books', 'learningPaths']) {
+    if (!(key in catalog)) errors.push(`missing root field: ${key}`);
+  }
+  requireString(errors, catalog.schemaVersion, 'schemaVersion', { allowEmpty: false });
+  if (typeof catalog.updatedAt !== 'string' || !dateRe.test(catalog.updatedAt)) {
+    errors.push('updatedAt must be YYYY-MM-DD');
+  }
+  if (!isObject(catalog.sourcePolicy) || catalog.sourcePolicy.canonical !== 'docs/_data/catalog.json') {
+    errors.push('sourcePolicy.canonical must be docs/_data/catalog.json');
+  } else {
+    requireStringArray(errors, catalog.sourcePolicy.derivedFiles, 'sourcePolicy.derivedFiles');
+    requireStringArray(errors, catalog.sourcePolicy.externalDynamicFields, 'sourcePolicy.externalDynamicFields');
+    requireString(errors, catalog.sourcePolicy.notes, 'sourcePolicy.notes', { allowEmpty: false });
+  }
+  const moduleCatalog = requireStringArray(errors, catalog.moduleCatalog, 'moduleCatalog');
+  const moduleSet = new Set(moduleCatalog);
+  if (moduleSet.size !== moduleCatalog.length) errors.push('moduleCatalog contains duplicate values');
+
+  const books = requireArray(errors, catalog.books, 'books');
+  const seenIds = new Map();
+  const seenRepos = new Map();
+  const seenPages = new Map();
+  for (const [index, book] of books.entries()) {
+    const prefix = `books[${index}]`;
+    if (!isObject(book)) {
+      errors.push(`${prefix} must be an object`);
+      continue;
+    }
+    for (const field of requiredBookFields) {
+      if (!(field in book)) errors.push(`${prefix}.${field} is required`);
+    }
+    if (typeof book.id !== 'string' || !idRe.test(book.id)) errors.push(`${prefix}.id is invalid`);
+    if (seenIds.has(book.id)) errors.push(`duplicate book id: ${book.id}`);
+    seenIds.set(book.id, prefix);
+    if (typeof book.displayOrder !== 'number') errors.push(`${prefix}.displayOrder must be a number`);
+    if (!isObject(book.title)) {
+      errors.push(`${prefix}.title must be an object`);
+    } else {
+      requireString(errors, book.title.ja, `${prefix}.title.ja`, { allowEmpty: false });
+      requireString(errors, book.title.en, `${prefix}.title.en`, { allowEmpty: false });
+    }
+    if (book.officialEnglishTitle !== null && typeof book.officialEnglishTitle !== 'string') {
+      errors.push(`${prefix}.officialEnglishTitle must be string or null`);
+    }
+    if (!allowedBookStatus.has(book.status)) errors.push(`${prefix}.status has invalid value: ${book.status}`);
+    if (book.repo !== null) {
+      if (typeof book.repo !== 'string' || !repoRe.test(book.repo)) errors.push(`${prefix}.repo is invalid`);
+      if (seenRepos.has(book.repo)) errors.push(`duplicate repo: ${book.repo}`);
+      seenRepos.set(book.repo, prefix);
+    }
+    if (!allowedRepoVisibility.has(book.repoVisibility)) errors.push(`${prefix}.repoVisibility invalid: ${book.repoVisibility}`);
+    if (book.pagesUrl !== null) {
+      if (typeof book.pagesUrl !== 'string' || !pagesRe.test(book.pagesUrl)) errors.push(`${prefix}.pagesUrl is invalid`);
+      if (seenPages.has(book.pagesUrl)) errors.push(`duplicate pagesUrl: ${book.pagesUrl}`);
+      seenPages.set(book.pagesUrl, prefix);
+    }
+    if (!allowedPublicationScope.has(book.publicationScope)) errors.push(`${prefix}.publicationScope invalid: ${book.publicationScope}`);
+    if (!allowedCountingGroup.has(book.countingGroup)) errors.push(`${prefix}.countingGroup invalid: ${book.countingGroup}`);
+    if (typeof book.countedInMainLineup !== 'boolean') errors.push(`${prefix}.countedInMainLineup must be boolean`);
+    for (const field of ['tags', 'levels', 'roles', 'audiences', 'prerequisites', 'recommendedAfter', 'relatedEditions', 'notes']) {
+      requireStringArray(errors, book[field], `${prefix}.${field}`);
+    }
+    requireStringArray(errors, book.languages, `${prefix}.languages`, { minItems: 1 });
+    requireStringArray(errors, book.sourceRefs, `${prefix}.sourceRefs`, { minItems: 1 });
+    for (const lang of book.languages || []) {
+      if (!allowedLanguages.has(lang)) errors.push(`${prefix}.languages has invalid value: ${lang}`);
+    }
+    if (!isObject(book.summary)) {
+      errors.push(`${prefix}.summary must be an object`);
+    } else {
+      requireString(errors, book.summary.ja, `${prefix}.summary.ja`);
+      requireString(errors, book.summary.en, `${prefix}.summary.en`);
+    }
+    if (!allowedReviewStatus.has(book.reviewStatus)) errors.push(`${prefix}.reviewStatus invalid: ${book.reviewStatus}`);
+    for (const field of ['lastReviewedAt', 'addedAt', 'updatedAt']) {
+      if (book[field] !== null && (typeof book[field] !== 'string' || !dateRe.test(book[field]))) {
+        errors.push(`${prefix}.${field} must be YYYY-MM-DD or null`);
+      }
+    }
+    if (book.reviewIssue !== null && (!Number.isInteger(book.reviewIssue) || book.reviewIssue < 1)) {
+      errors.push(`${prefix}.reviewIssue must be positive integer or null`);
+    }
+    if (!isObject(book.ux)) {
+      errors.push(`${prefix}.ux must be an object`);
+    } else {
+      if (!allowedProfiles.has(book.ux.profile)) errors.push(`${prefix}.ux.profile invalid: ${book.ux.profile}`);
+      if (!isObject(book.ux.modules)) {
+        errors.push(`${prefix}.ux.modules must be an object`);
+      } else {
+        for (const [moduleName, enabled] of Object.entries(book.ux.modules)) {
+          if (!moduleSet.has(moduleName)) errors.push(`${prefix}.ux.modules has unknown module: ${moduleName}`);
+          if (typeof enabled !== 'boolean') errors.push(`${prefix}.ux.modules.${moduleName} must be boolean`);
+        }
+      }
+    }
+    if (book.status === 'planned') {
+      if (book.repoVisibility !== 'not-created') errors.push(`${prefix}: planned book must use repoVisibility=not-created`);
+      if (book.pagesUrl !== null) errors.push(`${prefix}: planned book must not define pagesUrl`);
+      if (book.publicationScope !== 'planned') errors.push(`${prefix}: planned book must use publicationScope=planned`);
+    }
+    if (book.status === 'published') {
+      if (!book.repo) errors.push(`${prefix}: published book must define repo`);
+      if (!book.pagesUrl) errors.push(`${prefix}: published book must define pagesUrl`);
+      if (book.repoVisibility === 'not-created') errors.push(`${prefix}: published book cannot use repoVisibility=not-created`);
+    }
+    if (book.repoVisibility === 'private' && book.publicationScope !== 'free-preview') {
+      errors.push(`${prefix}: private managed book must declare publicationScope=free-preview`);
+    }
+    if (book.countedInMainLineup && book.countingGroup !== 'main-lineup') {
+      errors.push(`${prefix}: countedInMainLineup=true requires countingGroup=main-lineup`);
+    }
+  }
+
+  const idSet = new Set(books.map((book) => book?.id).filter(Boolean));
+  for (const book of books) {
+    if (!book || !book.id) continue;
+    for (const field of ['prerequisites', 'recommendedAfter', 'relatedEditions']) {
+      for (const targetId of book[field] || []) {
+        if (!idSet.has(targetId)) errors.push(`${book.id}.${field} references unknown book id: ${targetId}`);
+      }
+    }
+  }
+
+  const expected = catalog.expectedCounts || {};
+  const actualMain = books.filter((book) => book.countingGroup === 'main-lineup' && book.countedInMainLineup).length;
+  const actualPlanned = books.filter((book) => book.countingGroup === 'planned').length;
+  const actualRelated = books.filter((book) => book.countingGroup === 'related-independent').length;
+  if (expected.mainLineup !== actualMain) errors.push(`mainLineup count mismatch: expected ${expected.mainLineup}, got ${actualMain}`);
+  if (expected.planned !== actualPlanned) errors.push(`planned count mismatch: expected ${expected.planned}, got ${actualPlanned}`);
+  if (expected.relatedIndependent !== actualRelated) errors.push(`relatedIndependent count mismatch: expected ${expected.relatedIndependent}, got ${actualRelated}`);
+
+  const learningPaths = requireArray(errors, catalog.learningPaths, 'learningPaths');
+  const pathIds = new Set();
+  for (const [index, learningPath] of learningPaths.entries()) {
+    const prefix = `learningPaths[${index}]`;
+    if (!isObject(learningPath)) {
+      errors.push(`${prefix} must be an object`);
+      continue;
+    }
+    if (pathIds.has(learningPath.id)) errors.push(`duplicate learning path id: ${learningPath.id}`);
+    pathIds.add(learningPath.id);
+    requireStringArray(errors, learningPath.bookIds, `${prefix}.bookIds`, { minItems: 1 });
+    requireStringArray(errors, learningPath.nextPathIds, `${prefix}.nextPathIds`);
+    for (const bookId of learningPath.bookIds || []) {
+      if (!idSet.has(bookId)) errors.push(`${prefix}.bookIds references unknown book id: ${bookId}`);
+    }
+  }
+  for (const [index, learningPath] of learningPaths.entries()) {
+    for (const nextId of learningPath.nextPathIds || []) {
+      if (!pathIds.has(nextId)) errors.push(`learningPaths[${index}].nextPathIds references unknown path id: ${nextId}`);
+    }
+  }
+  return errors;
+}
+
+export function prerequisiteCycles(catalog) {
+  const books = catalog.books || [];
+  const graph = new Map(books.map((book) => [book.id, book.prerequisites || []]));
+  const visiting = new Set();
+  const visited = new Set();
+  const cycles = [];
+  const stack = [];
+
+  function visit(id) {
+    if (visiting.has(id)) {
+      const start = stack.indexOf(id);
+      cycles.push([...stack.slice(start), id]);
+      return;
+    }
+    if (visited.has(id)) return;
+    visiting.add(id);
+    stack.push(id);
+    for (const next of graph.get(id) || []) {
+      if (graph.has(next)) visit(next);
+    }
+    stack.pop();
+    visiting.delete(id);
+    visited.add(id);
+  }
+
+  for (const id of graph.keys()) visit(id);
+  return cycles;
+}
+
+export function learningPathCycles(catalog) {
+  const paths = catalog.learningPaths || [];
+  const graph = new Map(paths.map((item) => [item.id, item.nextPathIds || []]));
+  const visiting = new Set();
+  const visited = new Set();
+  const cycles = [];
+  const stack = [];
+
+  function visit(id) {
+    if (visiting.has(id)) {
+      const start = stack.indexOf(id);
+      cycles.push([...stack.slice(start), id]);
+      return;
+    }
+    if (visited.has(id)) return;
+    visiting.add(id);
+    stack.push(id);
+    for (const next of graph.get(id) || []) {
+      if (graph.has(next)) visit(next);
+    }
+    stack.pop();
+    visiting.delete(id);
+    visited.add(id);
+  }
+
+  for (const id of graph.keys()) visit(id);
+  return cycles;
+}
+
+export function legacyRegistryFromCatalog(catalog) {
+  const books = {};
+  for (const book of [...catalog.books].sort((a, b) => String(a.id).localeCompare(String(b.id)))) {
+    if (book.status !== 'published') continue;
+    if (book.countingGroup !== 'main-lineup') continue;
+    if (!book.repo || !book.pagesUrl) continue;
+    const legacyNotes = (book.notes || []).filter(
+      (note) => !note.includes('日本語個別概要') && !note.includes('UX profile/modules')
+    );
+    books[book.id] = {
+      repo: book.repo,
+      pages: book.pagesUrl,
+      profile: book.ux.profile,
+      modules: book.ux.modules,
+      notes: legacyNotes.join(' / ') || 'catalog generated'
+    };
+    if (book.repoVisibility !== 'public') books[book.id].repoVisibility = book.repoVisibility;
+    if (book.publicationScope === 'free-preview') {
+      books[book.id].publicationModel = 'free-preview-and-paid-edition';
+      books[book.id].pagesPublicationScope = 'free-preview-aligned-with-zenn-free-scope';
+    }
+    const accessNote =
+      (book.notes || []).find((note) => note.includes('Private')) ||
+      (book.notes || []).find((note) => note.includes('無料公開範囲'));
+    if (accessNote) books[book.id].accessNote = accessNote;
+  }
+  return {
+    schemaVersion: '1.0.0',
+    updatedAt: catalog.updatedAt,
+    generatedFrom: 'docs/_data/catalog.json',
+    modulesCatalog: catalog.moduleCatalog,
+    books
+  };
+}

--- a/scripts/generate-catalog-derived.mjs
+++ b/scripts/generate-catalog-derived.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import { DEFAULT_CATALOG_PATH, DEFAULT_REGISTRY_PATH, legacyRegistryFromCatalog, loadCatalog, writeJson } from './catalog-utils.mjs';
+
+const check = process.argv.includes('--check');
+const catalog = loadCatalog(DEFAULT_CATALOG_PATH);
+const registry = legacyRegistryFromCatalog(catalog);
+const rendered = `${JSON.stringify(registry, null, 2)}\n`;
+if (check) {
+  const current = fs.existsSync(DEFAULT_REGISTRY_PATH) ? fs.readFileSync(DEFAULT_REGISTRY_PATH, 'utf8') : '';
+  if (current !== rendered) {
+    console.error(`❌ generated file is out of sync: ${DEFAULT_REGISTRY_PATH}`);
+    process.exit(1);
+  }
+  console.log('✅ generated catalog-derived files are in sync');
+} else {
+  writeJson(DEFAULT_REGISTRY_PATH, registry);
+  console.log(`✅ wrote ${DEFAULT_REGISTRY_PATH}`);
+}

--- a/scripts/generate-progress-report.js
+++ b/scripts/generate-progress-report.js
@@ -2,9 +2,10 @@
 
 /*
  * Generates docs/progress_report.md (and tmp/book_status.json) from
- * docs/publishing/book-registry.json.
+ * docs/_data/catalog.json.
  *
  * Motivation:
+ * - Keep docs/_data/catalog.json as the single metadata source of truth
  * - Avoid hardcoded book lists
  * - Reduce GitHub API calls (GraphQL batching) to mitigate 429
  */
@@ -184,44 +185,41 @@ async function main() {
   }
 
   const repoRoot = path.join(__dirname, "..");
-  const registryPath = path.join(
-    repoRoot,
-    "docs",
-    "publishing",
-    "book-registry.json"
-  );
+  const catalogPath = path.join(repoRoot, "docs", "_data", "catalog.json");
   const outMdPath = path.join(repoRoot, "docs", "progress_report.md");
   const outJsonPath = path.join(repoRoot, "tmp", "book_status.json");
 
-  if (!fs.existsSync(registryPath)) {
-    fail(`book-registry が見つかりません: ${registryPath}`);
+  if (!fs.existsSync(catalogPath)) {
+    fail(`catalog が見つかりません: ${catalogPath}`);
   }
 
-  let registry;
+  let catalog;
   try {
-    registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+    catalog = JSON.parse(fs.readFileSync(catalogPath, "utf8"));
   } catch (e) {
-    fail(`book-registry の JSON 解析に失敗しました: ${e.message}`);
+    fail(`catalog の JSON 解析に失敗しました: ${e.message}`);
   }
 
-  const books = registry?.books;
-  if (!books || typeof books !== "object" || Array.isArray(books)) {
-    fail("book-registry の books が不正です");
+  const books = catalog?.books;
+  if (!Array.isArray(books)) {
+    fail("catalog の books が不正です");
   }
 
-  const entries = Object.keys(books)
-    .sort()
-    .map((bookName) => {
-      const entry = books[bookName] || {};
+  const entries = books
+    .filter(
+      (entry) =>
+        entry.status === "published" &&
+        entry.countingGroup === "main-lineup" &&
+        entry.countedInMainLineup === true &&
+        entry.repo &&
+        entry.pagesUrl
+    )
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+    .map((entry) => {
+      const bookName = entry.id;
       const repo = entry.repo;
-      const pages = entry.pages;
+      const pages = entry.pagesUrl;
       const repoVisibility = entry.repoVisibility || "public";
-      if (!repo || typeof repo !== "string") {
-        fail(`${bookName}: repo が不正です`);
-      }
-      if (!pages || typeof pages !== "string") {
-        fail(`${bookName}: pages が不正です`);
-      }
       if (!["public", "private"].includes(repoVisibility)) {
         fail(`${bookName}: repoVisibility が不正です (${repoVisibility})`);
       }
@@ -229,6 +227,9 @@ async function main() {
       if (!owner || !name) {
         fail(`${bookName}: repo の形式が不正です (${repo})`);
       }
+      const accessNote =
+        (entry.notes || []).find((note) => String(note).includes("Private")) ||
+        (entry.notes || []).find((note) => String(note).includes("無料公開範囲"));
       return {
         bookName,
         owner,
@@ -236,8 +237,11 @@ async function main() {
         repo,
         pages,
         repoVisibility,
-        pagesPublicationScope: entry.pagesPublicationScope || null,
-        accessNote: entry.accessNote || null,
+        pagesPublicationScope:
+          entry.publicationScope === "free-preview"
+            ? "free-preview-aligned-with-zenn-free-scope"
+            : null,
+        accessNote: accessNote || null,
         isPrivateManaged: repoVisibility === "private",
       };
     });
@@ -360,7 +364,7 @@ async function main() {
     "備考: `linux-infra-textbook` は `linux-infra-textbook2` に置換済みの旧版（アーカイブ）"
   );
   md.push("");
-  md.push("生成元: `docs/publishing/book-registry.json`");
+  md.push("生成元: `docs/_data/catalog.json`");
   md.push("");
 
   fs.mkdirSync(path.dirname(outMdPath), { recursive: true });

--- a/scripts/test-catalog-fixtures.mjs
+++ b/scripts/test-catalog-fixtures.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { ROOT } from './catalog-utils.mjs';
+
+const cases = [
+  { file: 'tests/fixtures/catalog-valid.json', valid: true, script: 'scripts/validate-catalog.mjs' },
+  {
+    file: 'tests/fixtures/catalog-invalid-duplicate-id.json',
+    valid: false,
+    script: 'scripts/validate-catalog.mjs',
+    mustContain: 'duplicate book id'
+  },
+  {
+    file: 'tests/fixtures/catalog-invalid-missing-prereq.json',
+    valid: false,
+    script: 'scripts/validate-catalog.mjs',
+    mustContain: 'references unknown book id'
+  },
+  {
+    file: 'tests/fixtures/catalog-invalid-cycle.json',
+    valid: false,
+    script: 'scripts/validate-learning-graph.mjs',
+    mustContain: 'cycle detected'
+  },
+  {
+    file: 'tests/fixtures/catalog-invalid-private-scope.json',
+    valid: false,
+    script: 'scripts/validate-catalog.mjs',
+    mustContain: 'private managed book must declare publicationScope=free-preview'
+  }
+];
+
+let failed = 0;
+for (const testCase of cases) {
+  const result = spawnSync(process.execPath, [path.join(ROOT, testCase.script), path.join(ROOT, testCase.file)], {
+    cwd: ROOT,
+    encoding: 'utf8'
+  });
+  const output = [result.stdout || '', result.stderr || ''].join('\n');
+  const statusPassed = testCase.valid ? result.status === 0 : result.status !== 0;
+  const outputPassed = !testCase.mustContain || output.includes(testCase.mustContain);
+  const passed = statusPassed && outputPassed;
+  if (!passed) {
+    failed++;
+    console.error(`❌ fixture expectation failed: ${testCase.file}`);
+    console.error(result.stdout);
+    console.error(result.stderr);
+  } else {
+    console.log(`✅ fixture ${testCase.valid ? 'valid' : 'invalid'} as expected: ${testCase.file}`);
+  }
+}
+if (failed > 0) process.exit(1);

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { loadCatalog, validateCatalog, DEFAULT_CATALOG_PATH } from './catalog-utils.mjs';
+
+const catalogPath = process.argv[2] || DEFAULT_CATALOG_PATH;
+const catalog = loadCatalog(catalogPath);
+const errors = validateCatalog(catalog);
+if (errors.length > 0) {
+  for (const error of errors) console.error(`❌ ${error}`);
+  process.exit(1);
+}
+console.log(`✅ catalog OK (${catalog.books.length} records, ${catalog.learningPaths.length} learning paths)`);

--- a/scripts/validate-learning-graph.mjs
+++ b/scripts/validate-learning-graph.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { loadCatalog, prerequisiteCycles, learningPathCycles, DEFAULT_CATALOG_PATH } from './catalog-utils.mjs';
+
+const catalogPath = process.argv[2] || DEFAULT_CATALOG_PATH;
+const catalog = loadCatalog(catalogPath);
+const cycles = [
+  ...prerequisiteCycles(catalog).map((cycle) => `book prerequisites: ${cycle.join(' -> ')}`),
+  ...learningPathCycles(catalog).map((cycle) => `learning paths: ${cycle.join(' -> ')}`)
+];
+if (cycles.length > 0) {
+  for (const cycle of cycles) console.error(`❌ cycle detected: ${cycle}`);
+  process.exit(1);
+}
+console.log('✅ learning graph OK (no prerequisite/path cycles)');

--- a/tests/fixtures/catalog-invalid-cycle.json
+++ b/tests/fixtures/catalog-invalid-cycle.json
@@ -1,0 +1,195 @@
+{
+  "schemaVersion": "1.0.0",
+  "updatedAt": "2026-07-10",
+  "sourcePolicy": {
+    "canonical": "docs/_data/catalog.json",
+    "derivedFiles": [
+      "docs/publishing/book-registry.json"
+    ],
+    "externalDynamicFields": [
+      "stars",
+      "openIssues",
+      "updatedAtFromGitHub",
+      "openPRs",
+      "repoAvailabilityStatus"
+    ],
+    "notes": "GitHub APIから取得するStar数、Open Issue数、リポジトリ更新日時は正本へ保存しない。"
+  },
+  "expectedCounts": {
+    "mainLineup": 2,
+    "planned": 0,
+    "relatedIndependent": 0
+  },
+  "moduleCatalog": [
+    "quickStart",
+    "readingGuide",
+    "checklistPack",
+    "troubleshootingFlow",
+    "conceptMap",
+    "figureIndex",
+    "legalNotice",
+    "glossary"
+  ],
+  "books": [
+    {
+      "id": "illustrated-linux-basics-book",
+      "displayOrder": 1,
+      "title": {
+        "ja": "図解でわかるLinux基礎",
+        "en": "図解でわかるLinux基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/illustrated-linux-basics-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/illustrated-linux-basics-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "A visual introduction to Linux basics, core commands, filesystems, networking, and containers."
+      },
+      "prerequisites": [
+        "wsl2-linux-essentials-book"
+      ],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "wsl2-linux-essentials-book",
+      "displayOrder": 2,
+      "title": {
+        "ja": "やさしく学ぶLinux WSL2ではじめる基礎",
+        "en": "やさしく学ぶLinux WSL2ではじめる基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/wsl2-linux-essentials-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/wsl2-linux-essentials-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Uses WSL2 on Windows as a safe learning environment for Linux setup, shell usage, processes, networking, and scripting."
+      },
+      "prerequisites": [
+        "illustrated-linux-basics-book"
+      ],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    }
+  ],
+  "learningPaths": [
+    {
+      "id": "fixture-path",
+      "title": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "description": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "bookIds": [
+        "illustrated-linux-basics-book",
+        "wsl2-linux-essentials-book"
+      ],
+      "nextPathIds": []
+    }
+  ]
+}

--- a/tests/fixtures/catalog-invalid-duplicate-id.json
+++ b/tests/fixtures/catalog-invalid-duplicate-id.json
@@ -1,0 +1,190 @@
+{
+  "schemaVersion": "1.0.0",
+  "updatedAt": "2026-07-10",
+  "sourcePolicy": {
+    "canonical": "docs/_data/catalog.json",
+    "derivedFiles": [
+      "docs/publishing/book-registry.json"
+    ],
+    "externalDynamicFields": [
+      "stars",
+      "openIssues",
+      "updatedAtFromGitHub",
+      "openPRs",
+      "repoAvailabilityStatus"
+    ],
+    "notes": "GitHub APIから取得するStar数、Open Issue数、リポジトリ更新日時は正本へ保存しない。"
+  },
+  "expectedCounts": {
+    "mainLineup": 2,
+    "planned": 0,
+    "relatedIndependent": 0
+  },
+  "moduleCatalog": [
+    "quickStart",
+    "readingGuide",
+    "checklistPack",
+    "troubleshootingFlow",
+    "conceptMap",
+    "figureIndex",
+    "legalNotice",
+    "glossary"
+  ],
+  "books": [
+    {
+      "id": "illustrated-linux-basics-book",
+      "displayOrder": 1,
+      "title": {
+        "ja": "図解でわかるLinux基礎",
+        "en": "図解でわかるLinux基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/illustrated-linux-basics-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/illustrated-linux-basics-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "A visual introduction to Linux basics, core commands, filesystems, networking, and containers."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "illustrated-linux-basics-book",
+      "displayOrder": 2,
+      "title": {
+        "ja": "やさしく学ぶLinux WSL2ではじめる基礎",
+        "en": "やさしく学ぶLinux WSL2ではじめる基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/wsl2-linux-essentials-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/wsl2-linux-essentials-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Uses WSL2 on Windows as a safe learning environment for Linux setup, shell usage, processes, networking, and scripting."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    }
+  ],
+  "learningPaths": [
+    {
+      "id": "fixture-path",
+      "title": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "description": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "bookIds": [
+        "illustrated-linux-basics-book"
+      ],
+      "nextPathIds": []
+    }
+  ]
+}

--- a/tests/fixtures/catalog-invalid-missing-prereq.json
+++ b/tests/fixtures/catalog-invalid-missing-prereq.json
@@ -1,0 +1,193 @@
+{
+  "schemaVersion": "1.0.0",
+  "updatedAt": "2026-07-10",
+  "sourcePolicy": {
+    "canonical": "docs/_data/catalog.json",
+    "derivedFiles": [
+      "docs/publishing/book-registry.json"
+    ],
+    "externalDynamicFields": [
+      "stars",
+      "openIssues",
+      "updatedAtFromGitHub",
+      "openPRs",
+      "repoAvailabilityStatus"
+    ],
+    "notes": "GitHub APIから取得するStar数、Open Issue数、リポジトリ更新日時は正本へ保存しない。"
+  },
+  "expectedCounts": {
+    "mainLineup": 2,
+    "planned": 0,
+    "relatedIndependent": 0
+  },
+  "moduleCatalog": [
+    "quickStart",
+    "readingGuide",
+    "checklistPack",
+    "troubleshootingFlow",
+    "conceptMap",
+    "figureIndex",
+    "legalNotice",
+    "glossary"
+  ],
+  "books": [
+    {
+      "id": "illustrated-linux-basics-book",
+      "displayOrder": 1,
+      "title": {
+        "ja": "図解でわかるLinux基礎",
+        "en": "図解でわかるLinux基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/illustrated-linux-basics-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/illustrated-linux-basics-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "A visual introduction to Linux basics, core commands, filesystems, networking, and containers."
+      },
+      "prerequisites": [
+        "missing-book-id"
+      ],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "wsl2-linux-essentials-book",
+      "displayOrder": 2,
+      "title": {
+        "ja": "やさしく学ぶLinux WSL2ではじめる基礎",
+        "en": "やさしく学ぶLinux WSL2ではじめる基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/wsl2-linux-essentials-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/wsl2-linux-essentials-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Uses WSL2 on Windows as a safe learning environment for Linux setup, shell usage, processes, networking, and scripting."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    }
+  ],
+  "learningPaths": [
+    {
+      "id": "fixture-path",
+      "title": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "description": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "bookIds": [
+        "illustrated-linux-basics-book",
+        "wsl2-linux-essentials-book"
+      ],
+      "nextPathIds": []
+    }
+  ]
+}

--- a/tests/fixtures/catalog-invalid-private-scope.json
+++ b/tests/fixtures/catalog-invalid-private-scope.json
@@ -1,0 +1,192 @@
+{
+  "schemaVersion": "1.0.0",
+  "updatedAt": "2026-07-10",
+  "sourcePolicy": {
+    "canonical": "docs/_data/catalog.json",
+    "derivedFiles": [
+      "docs/publishing/book-registry.json"
+    ],
+    "externalDynamicFields": [
+      "stars",
+      "openIssues",
+      "updatedAtFromGitHub",
+      "openPRs",
+      "repoAvailabilityStatus"
+    ],
+    "notes": "GitHub APIから取得するStar数、Open Issue数、リポジトリ更新日時は正本へ保存しない。"
+  },
+  "expectedCounts": {
+    "mainLineup": 2,
+    "planned": 0,
+    "relatedIndependent": 0
+  },
+  "moduleCatalog": [
+    "quickStart",
+    "readingGuide",
+    "checklistPack",
+    "troubleshootingFlow",
+    "conceptMap",
+    "figureIndex",
+    "legalNotice",
+    "glossary"
+  ],
+  "books": [
+    {
+      "id": "illustrated-linux-basics-book",
+      "displayOrder": 1,
+      "title": {
+        "ja": "図解でわかるLinux基礎",
+        "en": "図解でわかるLinux基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/illustrated-linux-basics-book",
+      "repoVisibility": "private",
+      "pagesUrl": "https://itdojp.github.io/illustrated-linux-basics-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "A visual introduction to Linux basics, core commands, filesystems, networking, and containers."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。",
+        "fixture private scope invalid"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "wsl2-linux-essentials-book",
+      "displayOrder": 2,
+      "title": {
+        "ja": "やさしく学ぶLinux WSL2ではじめる基礎",
+        "en": "やさしく学ぶLinux WSL2ではじめる基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/wsl2-linux-essentials-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/wsl2-linux-essentials-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Uses WSL2 on Windows as a safe learning environment for Linux setup, shell usage, processes, networking, and scripting."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    }
+  ],
+  "learningPaths": [
+    {
+      "id": "fixture-path",
+      "title": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "description": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "bookIds": [
+        "illustrated-linux-basics-book",
+        "wsl2-linux-essentials-book"
+      ],
+      "nextPathIds": []
+    }
+  ]
+}

--- a/tests/fixtures/catalog-valid.json
+++ b/tests/fixtures/catalog-valid.json
@@ -1,0 +1,191 @@
+{
+  "schemaVersion": "1.0.0",
+  "updatedAt": "2026-07-10",
+  "sourcePolicy": {
+    "canonical": "docs/_data/catalog.json",
+    "derivedFiles": [
+      "docs/publishing/book-registry.json"
+    ],
+    "externalDynamicFields": [
+      "stars",
+      "openIssues",
+      "updatedAtFromGitHub",
+      "openPRs",
+      "repoAvailabilityStatus"
+    ],
+    "notes": "GitHub APIから取得するStar数、Open Issue数、リポジトリ更新日時は正本へ保存しない。"
+  },
+  "expectedCounts": {
+    "mainLineup": 2,
+    "planned": 0,
+    "relatedIndependent": 0
+  },
+  "moduleCatalog": [
+    "quickStart",
+    "readingGuide",
+    "checklistPack",
+    "troubleshootingFlow",
+    "conceptMap",
+    "figureIndex",
+    "legalNotice",
+    "glossary"
+  ],
+  "books": [
+    {
+      "id": "illustrated-linux-basics-book",
+      "displayOrder": 1,
+      "title": {
+        "ja": "図解でわかるLinux基礎",
+        "en": "図解でわかるLinux基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/illustrated-linux-basics-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/illustrated-linux-basics-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "A visual introduction to Linux basics, core commands, filesystems, networking, and containers."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    },
+    {
+      "id": "wsl2-linux-essentials-book",
+      "displayOrder": 2,
+      "title": {
+        "ja": "やさしく学ぶLinux WSL2ではじめる基礎",
+        "en": "やさしく学ぶLinux WSL2ではじめる基礎"
+      },
+      "officialEnglishTitle": null,
+      "status": "published",
+      "repo": "itdojp/wsl2-linux-essentials-book",
+      "repoVisibility": "public",
+      "pagesUrl": "https://itdojp.github.io/wsl2-linux-essentials-book/",
+      "publicationScope": "full-public",
+      "countingGroup": "main-lineup",
+      "countedInMainLineup": true,
+      "category": "beginner-track",
+      "subcategory": "未経験者向け",
+      "tags": [
+        "beginner-track"
+      ],
+      "levels": [
+        "beginner"
+      ],
+      "roles": [
+        "beginner"
+      ],
+      "audiences": [
+        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+      ],
+      "summary": {
+        "ja": "",
+        "en": "Uses WSL2 on Windows as a safe learning environment for Linux setup, shell usage, processes, networking, and scripting."
+      },
+      "prerequisites": [],
+      "estimatedWeeks": null,
+      "recommendedAfter": [],
+      "languages": [
+        "ja"
+      ],
+      "relatedEditions": [],
+      "reviewStatus": "reviewed",
+      "lastReviewedAt": null,
+      "reviewIssue": null,
+      "ux": {
+        "profile": "A",
+        "modules": {
+          "quickStart": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
+          "conceptMap": true,
+          "figureIndex": false,
+          "legalNotice": false,
+          "glossary": true
+        }
+      },
+      "addedAt": null,
+      "updatedAt": "2026-07-10",
+      "notes": [
+        "暫定割当（要確認）",
+        "日本語個別概要はREADME公開カタログ上で未記載。",
+        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+      ],
+      "sourceRefs": [
+        "README.md",
+        "docs/en/index.md",
+        "docs/publishing/book-registry.json"
+      ]
+    }
+  ],
+  "learningPaths": [
+    {
+      "id": "fixture-path",
+      "title": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "description": {
+        "ja": "fixture",
+        "en": "fixture"
+      },
+      "bookIds": [
+        "illustrated-linux-basics-book",
+        "wsl2-linux-essentials-book"
+      ],
+      "nextPathIds": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Refs #176.

This PR implements the first #176 slice: catalog source-of-truth foundation plus effective validation. It intentionally does not change the public site layout, URLs, or downstream book repositories.

## Changes

- Add `docs/_data/catalog.json` as the canonical book metadata source with 49 records:
  - 41 counted main-lineup published books
  - 7 planned books
  - 1 related independent English book excluded from the Japanese main-lineup count
- Add `schemas/catalog.schema.json` and npm validation/generation scripts:
  - `scripts/validate-catalog.mjs`
  - `scripts/validate-learning-graph.mjs`
  - `scripts/generate-catalog-derived.mjs`
  - `scripts/test-catalog-fixtures.mjs`
- Add invalid fixtures for duplicate IDs, missing prerequisite IDs, prerequisite cycles, and invalid Private-managed publication scope.
- Generate compatibility `docs/publishing/book-registry.json` from the catalog while preserving existing main-lineup registry behavior.
- Add `docs/publishing/catalog-migration-report.md` documenting migration sources, counts, known inconsistencies, and intentionally unresolved items.
- Move existing progress/reporting and quality-sprint metadata reads from the legacy registry toward the catalog.
- Replace grep-only / placeholder learning-path CI checks with `npm run verify`.

## Validation

- `npm ci`
- `npm run verify`
- `node scripts/validate-ux-registry.js`
- `npm audit --audit-level=moderate`
- JSON/YAML parse check for catalog/schema/fixtures/workflows
- Local markdown `.md` link check matching the workflow logic
- `npm run generate` hash check: `docs/publishing/book-registry.json` unchanged after generation
- `git diff --check`

## Notes

- Dynamic GitHub fields such as stars, open issue/PR counts, repository availability, and repository update time remain outside the canonical catalog.
- `README.md`, `docs/index.md`, `docs/en/index.md`, and the reader-facing site structure are left for later #176 phases.
- `books/existing-books.md` still contains older metadata such as `cloud-infra-handbook`; this is recorded in the migration report rather than silently overwritten.
