### PR TITLE
Add catalog-driven site entry pages

### DIFF
--- a/.github/workflows/validate-learning-paths.yml
+++ b/.github/workflows/validate-learning-paths.yml
@@ -6,6 +6,14 @@ on:
     paths:
       - 'roadmap/**'
       - 'books/**'
+      - 'README.md'
+      - 'docs/index.md'
+      - 'docs/en/**'
+      - 'docs/_layouts/**'
+      - 'docs/books/**'
+      - 'docs/paths/**'
+      - 'docs/404.html'
+      - '.github/workflows/validate-learning-paths.yml'
       - 'docs/_data/**'
       - 'docs/publishing/book-registry.json'
       - 'schemas/**'
@@ -18,6 +26,14 @@ on:
     paths:
       - 'roadmap/**'
       - 'books/**'
+      - 'README.md'
+      - 'docs/index.md'
+      - 'docs/en/**'
+      - 'docs/_layouts/**'
+      - 'docs/books/**'
+      - 'docs/paths/**'
+      - 'docs/404.html'
+      - '.github/workflows/validate-learning-paths.yml'
       - 'docs/_data/**'
       - 'docs/publishing/book-registry.json'
       - 'schemas/**'
@@ -82,6 +98,46 @@ jobs:
           done
 
           echo "✅ リンクチェック通過"
+
+  build-site:
+    runs-on: ubuntu-latest
+    name: Jekyllサイト生成チェック
+
+    steps:
+      - name: チェックアウト
+        uses: actions/checkout@v4
+
+      - name: Ruby設定
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Jekyllインストール
+        run: gem install jekyll -v 4.4.1
+
+      - name: Jekyll build
+        run: jekyll build --source docs --destination .site
+
+      - name: 主要ページ構造チェック
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          root = Path('.site')
+          checks = {
+              'index.html': ['<main id="main-content"', '本文へスキップ', '/books/', '/paths/'],
+              'books/index.html': ['書籍一覧', 'data-book-card', '全 49 件', 'ai-agent-collaboration-book'],
+              'paths/index.html': ['学習パス', 'beginner-linux', 'book-sequence'],
+              '404.html': ['ページが見つかりません', '/books/', '/paths/'],
+              'en/index.html': ['English Catalog', '<html lang="en"'],
+          }
+          for rel, markers in checks.items():
+              text = (root / rel).read_text(encoding='utf-8')
+              h1_count = text.lower().count('<h1')
+              missing = [marker for marker in markers if marker not in text]
+              if h1_count != 1 or missing:
+                  raise SystemExit(f'{rel}: h1_count={h1_count}, missing={missing}')
+          print('site structure OK')
+          PY
 
   validate-yaml-structure:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -7,9 +7,17 @@ Building Your Tech Career, One Book at a Time
 
 [日本語](https://itdojp.github.io/it-engineer-knowledge-architecture/) | [English](https://itdojp.github.io/it-engineer-knowledge-architecture/en/)
 
+主要入口:
+
+- [書籍一覧](https://itdojp.github.io/it-engineer-knowledge-architecture/books/) — 正本カタログから生成した全書籍カード
+- [学習パス](https://itdojp.github.io/it-engineer-knowledge-architecture/paths/) — 正本カタログの bookIds / nextPathIds から生成した読書順
+- [出版ガイド](https://itdojp.github.io/it-engineer-knowledge-architecture/publishing/) — 書籍制作・レビュー・公開運用の手引き
+
 - [日本語概要](#日本語概要)
 - [書籍一覧](#書籍一覧)
+- [正本カタログページ](https://itdojp.github.io/it-engineer-knowledge-architecture/books/)
 - [学習ロードマップ](#学習ロードマップ)
+- [正本学習パスページ](https://itdojp.github.io/it-engineer-knowledge-architecture/paths/)
 - [Professional Foundations（基礎リテラシー）](#professional-foundations基礎リテラシー)
 - [専門分野別学習パス](#専門分野別学習パス)
 - [計画書籍](#計画書籍)

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,20 @@
+---
+layout: default
+title: ページが見つかりません | IT Engineer Knowledge Architecture
+description: 指定されたページは見つかりませんでした。
+permalink: /404.html
+---
+
+<h1>ページが見つかりません</h1>
+
+<p>指定されたページは移動、削除、または未公開の可能性があります。</p>
+
+<div class="notice-box">
+  <p>次の入口から目的の情報を探してください。</p>
+  <ul>
+    <li><a href="{{ '/' | relative_url }}">ホーム</a></li>
+    <li><a href="{{ '/books/' | relative_url }}">書籍一覧</a></li>
+    <li><a href="{{ '/paths/' | relative_url }}">学習パス</a></li>
+    <li><a href="{{ '/publishing/' | relative_url }}">出版ガイド</a></li>
+  </ul>
+</div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,118 +3,355 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
-    <title>{{ page.title | default: site.title }}</title>
-    <meta name="description" content="{{ page.description | default: site.description }}">
-    
+
+    {% assign canonical_path = page.url | relative_url %}
+    {% unless canonical_path contains '/it-engineer-knowledge-architecture/' %}
+      {% assign canonical_path = canonical_path | prepend: '/it-engineer-knowledge-architecture' %}
+    {% endunless %}
+    {% assign canonical_url = canonical_path | prepend: 'https://itdojp.github.io' %}
+    <title>{{ page.title | default: site.title | default: 'IT Engineer Knowledge Architecture' }}</title>
+    <meta name="description" content="{{ page.description | default: site.description | default: '実務で活かせるITエンジニア学習ロードマップ' | escape }}">
+    <link rel="canonical" href="{{ canonical_url }}">
+    <link rel="alternate" hreflang="ja" href="https://itdojp.github.io{{ '/it-engineer-knowledge-architecture/' }}">
+    <link rel="alternate" hreflang="en" href="https://itdojp.github.io{{ '/it-engineer-knowledge-architecture/en/' }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ page.title | default: site.title | default: 'IT Engineer Knowledge Architecture' | escape }}">
+    <meta property="og:description" content="{{ page.description | default: site.description | default: '実務で活かせるITエンジニア学習ロードマップ' | escape }}">
+    <meta property="og:url" content="{{ canonical_url }}">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "IT Engineer Knowledge Architecture",
+      "url": "https://itdojp.github.io/it-engineer-knowledge-architecture/",
+      "inLanguage": ["ja", "en"]
+    }
+    </script>
+
     <!-- Favicon -->
     <link rel="icon" type="image/png" sizes="48x48" href="{{ '/assets/images/itdo_logo_48x48_blue.png' | relative_url }}">
     <link rel="shortcut icon" type="image/png" href="{{ '/assets/images/itdo_logo_48x48_blue.png' | relative_url }}">
-    
+
     <!-- GitHub Pages default theme CSS -->
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    
+
     <!-- Custom styles -->
     <style>
+        :root {
+            --text: #1f2937;
+            --muted: #4b5563;
+            --link: #005ea8;
+            --link-hover: #003f73;
+            --border: #d1d5db;
+            --surface: #f8fafc;
+            --surface-strong: #eef2f7;
+            --accent: #1d4ed8;
+            --focus: #ffbf47;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html {
+            scroll-behavior: smooth;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            html {
+                scroll-behavior: auto;
+            }
+
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.01ms !important;
+            }
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
             line-height: 1.6;
-            color: #333;
+            color: var(--text);
             max-width: 1200px;
             margin: 0 auto;
             padding: 20px;
+            background: #fff;
         }
-        
-        .header {
-            border-bottom: 2px solid #eee;
+
+        .skip-link {
+            position: absolute;
+            left: 1rem;
+            top: 0;
+            transform: translateY(-120%);
+            background: #111827;
+            color: #fff;
+            padding: 0.75rem 1rem;
+            z-index: 1000;
+            border-radius: 0 0 0.375rem 0.375rem;
+        }
+
+        .skip-link:focus,
+        .skip-link:focus-visible {
+            transform: translateY(0);
+            outline: 3px solid var(--focus);
+            outline-offset: 2px;
+        }
+
+        .site-header {
+            border-bottom: 2px solid var(--border);
             margin-bottom: 30px;
             padding-bottom: 20px;
         }
-        
-        .header h1 {
-            color: #2c3e50;
-            margin-bottom: 10px;
+
+        .site-title {
+            color: #123047;
+            font-size: clamp(1.5rem, 4vw, 2rem);
+            font-weight: 700;
+            margin: 0 0 0.35rem;
         }
-        
+
+        .site-description {
+            color: var(--muted);
+            margin: 0 0 1rem;
+        }
+
+        .site-nav {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        .site-nav a {
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            display: inline-block;
+            padding: 0.4rem 0.75rem;
+            text-decoration: none;
+            background: #fff;
+        }
+
+        .site-nav a[aria-current="page"] {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: #fff;
+            font-weight: 700;
+        }
+
         .content {
             min-height: 70vh;
         }
-        
+
+        .content :target {
+            scroll-margin-top: 1rem;
+        }
+
         .footer {
-            border-top: 2px solid #eee;
+            border-top: 2px solid var(--border);
             margin-top: 50px;
             padding-top: 20px;
             text-align: center;
-            color: #7f8c8d;
+            color: var(--muted);
         }
-        
-        /* Link styles */
+
         a {
-            color: #3498db;
-            text-decoration: none;
-        }
-        
-        a:hover {
+            color: var(--link);
             text-decoration: underline;
+            text-underline-offset: 0.12em;
         }
-        
-        /* Code block styling */
+
+        a:hover {
+            color: var(--link-hover);
+        }
+
+        a:focus-visible,
+        button:focus-visible,
+        input:focus-visible,
+        select:focus-visible,
+        textarea:focus-visible {
+            outline: 3px solid var(--focus);
+            outline-offset: 2px;
+        }
+
         pre {
-            background: #f8f9fa;
-            border: 1px solid #e9ecef;
+            background: var(--surface);
+            border: 1px solid var(--border);
             border-radius: 5px;
             padding: 15px;
             overflow-x: auto;
         }
-        
+
         code {
-            background: #f8f9fa;
+            background: var(--surface);
             padding: 2px 6px;
             border-radius: 3px;
             font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
         }
-        
-        /* Table styling */
+
         table {
             border-collapse: collapse;
             width: 100%;
             margin: 20px 0;
         }
-        
-        th, td {
-            border: 1px solid #ddd;
-            padding: 12px;
+
+        caption {
+            caption-side: top;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
             text-align: left;
         }
-        
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px;
+            text-align: left;
+            vertical-align: top;
+        }
+
         th {
-            background-color: #f8f9fa;
+            background-color: var(--surface);
             font-weight: bold;
         }
-        
-        /* Custom continuous counter for all ordered lists */
-        .content {
+
+        .book-sequence {
             counter-reset: book-counter;
-        }
-        
-        .content ol {
             list-style: none;
+            padding-left: 0;
         }
-        
-        .content ol li {
+
+        .book-sequence > li {
             counter-increment: book-counter;
             position: relative;
-            padding-left: 2em;
+            padding-left: 2.2em;
+            margin-bottom: 0.5rem;
         }
-        
-        .content ol li::before {
+
+        .book-sequence > li::before {
             content: counter(book-counter) ". ";
             position: absolute;
             left: 0;
             font-weight: bold;
         }
-        
-        /* Responsive design */
+
+        .catalog-summary,
+        .filter-panel,
+        .book-card,
+        .path-card,
+        .notice-box {
+            border: 1px solid var(--border);
+            border-radius: 0.75rem;
+            background: #fff;
+            padding: 1rem;
+        }
+
+        .catalog-summary {
+            display: grid;
+            gap: 0.75rem;
+            grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+            background: var(--surface);
+            margin: 1.5rem 0;
+        }
+
+        .summary-metric {
+            background: #fff;
+            border: 1px solid var(--border);
+            border-radius: 0.5rem;
+            padding: 0.75rem;
+        }
+
+        .summary-metric strong {
+            display: block;
+            font-size: 1.5rem;
+        }
+
+        .filter-panel {
+            background: var(--surface);
+            display: grid;
+            gap: 0.75rem;
+            grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+            margin: 1.5rem 0;
+        }
+
+        .filter-panel label {
+            display: grid;
+            gap: 0.25rem;
+            font-weight: 700;
+        }
+
+        .filter-panel input,
+        .filter-panel select {
+            border: 1px solid var(--border);
+            border-radius: 0.375rem;
+            color: var(--text);
+            font: inherit;
+            padding: 0.45rem 0.55rem;
+        }
+
+        .book-grid,
+        .path-grid {
+            display: grid;
+            gap: 1rem;
+            grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+            margin: 1.5rem 0;
+        }
+
+        .book-card,
+        .path-card {
+            background: #fff;
+        }
+
+        .book-card h2,
+        .path-card h2 {
+            margin-top: 0;
+        }
+
+        .badge-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.35rem;
+            list-style: none;
+            margin: 0.75rem 0;
+            padding: 0;
+        }
+
+        .badge {
+            background: var(--surface-strong);
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            color: var(--text);
+            display: inline-block;
+            font-size: 0.875rem;
+            padding: 0.15rem 0.5rem;
+        }
+
+        .card-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .card-actions a,
+        .button-link {
+            background: var(--link);
+            border-radius: 0.375rem;
+            color: #fff;
+            display: inline-block;
+            padding: 0.45rem 0.7rem;
+            text-decoration: none;
+        }
+
+        .card-actions a.secondary,
+        .button-link.secondary {
+            background: #374151;
+        }
+
+        .notice-box {
+            background: var(--surface);
+            margin: 1rem 0;
+        }
+
         @media (max-width: 768px) {
             body {
                 padding: 10px;
@@ -135,16 +372,25 @@
     </style>
 </head>
 <body>
-    <div class="header">
-        <h1>{{ page.header_title | default: site.title | default: "IT Engineer Knowledge Architecture" }}</h1>
-        <p>{{ page.header_description | default: page.description | default: site.description | default: "実務で活かせるITエンジニア学習ロードマップ" }}</p>
-    </div>
-    
-    <main class="content">
+    <a class="skip-link" href="#main-content">本文へスキップ</a>
+
+    <header class="site-header" role="banner">
+        <div class="site-title">{{ page.header_title | default: site.title | default: "IT Engineer Knowledge Architecture" }}</div>
+        <p class="site-description">{{ page.header_description | default: page.description | default: site.description | default: "実務で活かせるITエンジニア学習ロードマップ" }}</p>
+        <nav class="site-nav" aria-label="主要ナビゲーション">
+            <a href="{{ '/' | relative_url }}"{% if page.url == '/' %} aria-current="page"{% endif %}>ホーム</a>
+            <a href="{{ '/books/' | relative_url }}"{% if page.url == '/books/' %} aria-current="page"{% endif %}>書籍一覧</a>
+            <a href="{{ '/paths/' | relative_url }}"{% if page.url == '/paths/' %} aria-current="page"{% endif %}>学習パス</a>
+            <a href="{{ '/publishing/' | relative_url }}"{% if page.url contains '/publishing/' %} aria-current="page"{% endif %}>出版ガイド</a>
+            <a href="{{ '/en/' | relative_url }}"{% if page.url == '/en/' %} aria-current="page"{% endif %}>English</a>
+        </nav>
+    </header>
+
+    <main id="main-content" class="content" tabindex="-1">
         {{ content }}
     </main>
-    
-    <footer class="footer">
+
+    <footer class="footer" role="contentinfo">
         <p>&copy; {{ site.time | date: "%Y" }} ITDO Inc. Content licensed under CC BY-NC-SA 4.0 (commercial use requires a separate agreement).</p>
         <p>
             <a href="https://github.com/itdojp/it-engineer-knowledge-architecture">GitHub</a> |

--- a/docs/books/index.html
+++ b/docs/books/index.html
@@ -1,0 +1,136 @@
+---
+layout: default
+title: 書籍一覧 | IT Engineer Knowledge Architecture
+description: IT Engineer Knowledge Architecture の全書籍カタログ。公開済み、計画中、関連する独立英語書籍を正本データから表示します。
+permalink: /books/
+---
+{% assign catalog = site.data.catalog %}
+{% assign books = catalog.books | sort: 'displayOrder' %}
+{% assign categories = books | map: 'category' | uniq | sort %}
+{% assign main_count = 0 %}
+{% assign planned_count = 0 %}
+{% assign related_count = 0 %}
+{% for book in books %}
+  {% if book.countingGroup == 'main-lineup' and book.countedInMainLineup %}{% assign main_count = main_count | plus: 1 %}{% endif %}
+  {% if book.countingGroup == 'planned' %}{% assign planned_count = planned_count | plus: 1 %}{% endif %}
+  {% if book.countingGroup == 'related-independent' %}{% assign related_count = related_count | plus: 1 %}{% endif %}
+{% endfor %}
+
+<h1>書籍一覧</h1>
+
+<p>このページは <code>docs/_data/catalog.json</code> を正本として生成する全書籍カタログです。JavaScript が無効な環境でも全件を閲覧できます。</p>
+
+<nav aria-label="このページ内の移動" class="notice-box">
+  <a href="#catalog-cards">カタログカードへ移動</a> |
+  <a href="{{ '/paths/' | relative_url }}">学習パスを見る</a> |
+  <a href="{{ '/' | relative_url }}">ホームへ戻る</a>
+</nav>
+
+<section class="catalog-summary" aria-label="カタログ集計">
+  <div class="summary-metric"><strong>{{ main_count }}</strong>メインライン公開書籍</div>
+  <div class="summary-metric"><strong>{{ planned_count }}</strong>計画書籍</div>
+  <div class="summary-metric"><strong>{{ related_count }}</strong>関連する独立英語書籍</div>
+  <div class="summary-metric"><strong>{{ books | size }}</strong>総レコード</div>
+</section>
+
+<section class="filter-panel" aria-label="書籍一覧の絞り込み">
+  <label>
+    キーワード
+    <input id="book-filter-keyword" type="search" placeholder="例: Kubernetes, AI, セキュリティ" autocomplete="off">
+  </label>
+  <label>
+    カテゴリ
+    <select id="book-filter-category">
+      <option value="">すべて</option>
+      {% for category in categories %}<option value="{{ category | escape }}">{{ category }}</option>{% endfor %}
+    </select>
+  </label>
+  <label>
+    公開状態
+    <select id="book-filter-status">
+      <option value="">すべて</option>
+      <option value="published">公開済み</option>
+      <option value="planned">計画中</option>
+    </select>
+  </label>
+  <label>
+    公開範囲
+    <select id="book-filter-scope">
+      <option value="">すべて</option>
+      <option value="full-public">完全公開</option>
+      <option value="free-preview">無料公開範囲</option>
+      <option value="planned">計画段階</option>
+    </select>
+  </label>
+</section>
+
+<p id="book-filter-result" aria-live="polite">全 {{ books | size }} 件を表示しています。</p>
+
+<section id="catalog-cards" class="book-grid" aria-label="書籍カタログカード">
+{% for book in books %}
+  {% assign summary = book.summary.ja %}
+  {% if summary == '' %}{% assign summary = book.summary.en %}{% endif %}
+  {% assign tags_text = book.tags | join: ' ' %}
+  {% assign search_text = book.id | append: ' ' | append: book.title.ja | append: ' ' | append: book.title.en | append: ' ' | append: summary | append: ' ' | append: tags_text %}
+  <article class="book-card" data-book-card data-category="{{ book.category | escape }}" data-status="{{ book.status | escape }}" data-scope="{{ book.publicationScope | escape }}" data-search="{{ search_text | downcase | escape }}">
+    <h2 id="{{ book.id }}">{{ book.displayOrder }}. {{ book.title.ja }}</h2>
+    {% if book.title.en != book.title.ja %}<p><strong>English:</strong> {{ book.title.en }}</p>{% endif %}
+    <p>{{ summary }}</p>
+    <ul class="badge-list" aria-label="属性">
+      <li class="badge">{{ book.status }}</li>
+      <li class="badge">{{ book.countingGroup }}</li>
+      <li class="badge">{{ book.publicationScope }}</li>
+      <li class="badge">{{ book.repoVisibility }}</li>
+      {% for level in book.levels %}<li class="badge">{{ level }}</li>{% endfor %}
+      {% for language in book.languages %}<li class="badge">{{ language }}</li>{% endfor %}
+    </ul>
+    {% if book.audiences and book.audiences.size > 0 %}<p><strong>対象:</strong> {{ book.audiences | join: ' / ' }}</p>{% endif %}
+    {% if book.prerequisites and book.prerequisites.size > 0 %}
+      <p><strong>前提:</strong>
+      {% for prerequisite in book.prerequisites %}<a href="#{{ prerequisite }}">{{ prerequisite }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
+      </p>
+    {% endif %}
+    <div class="card-actions">
+      {% if book.pagesUrl %}<a href="{{ book.pagesUrl }}">読む</a>{% endif %}
+      {% if book.repo and book.repoVisibility == 'public' %}<a class="secondary" href="https://github.com/{{ book.repo }}">リポジトリ</a>{% endif %}
+    </div>
+    {% if book.repoVisibility == 'private' %}<p><small>リポジトリ: Private（有料部分を含むため非公開）。Pages は無料公開範囲のみです。</small></p>{% endif %}
+    {% if book.status == 'planned' %}<p><small>計画書籍です。リポジトリとPagesは未公開または未作成です。</small></p>{% endif %}
+    {% if book.notes and book.notes.size > 0 %}<details><summary>移行メモ</summary><ul>{% for note in book.notes %}<li>{{ note }}</li>{% endfor %}</ul></details>{% endif %}
+  </article>
+{% endfor %}
+</section>
+
+<script>
+(function () {
+  const cards = Array.from(document.querySelectorAll('[data-book-card]'));
+  const keyword = document.getElementById('book-filter-keyword');
+  const category = document.getElementById('book-filter-category');
+  const status = document.getElementById('book-filter-status');
+  const scope = document.getElementById('book-filter-scope');
+  const result = document.getElementById('book-filter-result');
+  if (!cards.length || !keyword || !category || !status || !scope || !result) return;
+
+  function applyFilters() {
+    const q = keyword.value.trim().toLowerCase();
+    const categoryValue = category.value;
+    const statusValue = status.value;
+    const scopeValue = scope.value;
+    let visible = 0;
+    for (const card of cards) {
+      const matched = (!q || card.dataset.search.includes(q)) &&
+        (!categoryValue || card.dataset.category === categoryValue) &&
+        (!statusValue || card.dataset.status === statusValue) &&
+        (!scopeValue || card.dataset.scope === scopeValue);
+      card.hidden = !matched;
+      if (matched) visible += 1;
+    }
+    result.textContent = visible + ' / ' + cards.length + ' 件を表示しています。';
+  }
+
+  for (const control of [keyword, category, status, scope]) {
+    control.addEventListener('input', applyFilters);
+    control.addEventListener('change', applyFilters);
+  }
+}());
+</script>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,6 +10,12 @@ header_description: English catalog for the ITDO technical book lineup.
 
 [日本語]({{ '/' | relative_url }}) | **English**
 
+Primary entry points:
+
+- [Book catalog]({{ '/books/' | relative_url }}) — generated from the canonical catalog data
+- [Learning paths]({{ '/paths/' | relative_url }}) — generated from catalog book IDs and next-path IDs
+- [Publishing guide]({{ '/publishing/' | relative_url }}) — maintainer-facing publishing operations
+
 # English Catalog
 
 ## Project overview

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,17 @@ Building Your Tech Career, One Book at a Time
 
 [日本語]({{ '/' | relative_url }}) | [English]({{ '/en/' | relative_url }})
 
+主要入口:
+
+- [書籍一覧]({{ '/' | relative_url }}books/) — 正本カタログから生成した全書籍カード
+- [学習パス]({{ '/' | relative_url }}paths/) — 正本カタログの bookIds / nextPathIds から生成した読書順
+- [出版ガイド]({{ '/' | relative_url }}publishing/) — 書籍制作・レビュー・公開運用の手引き
+
 - [日本語概要](#日本語概要)
 - [書籍一覧](#書籍一覧)
+- [正本カタログページ]({{ '/' | relative_url }}books/)
 - [学習ロードマップ](#学習ロードマップ)
+- [正本学習パスページ]({{ '/' | relative_url }}paths/)
 - [Professional Foundations（基礎リテラシー）](#professional-foundations基礎リテラシー)
 - [専門分野別学習パス](#専門分野別学習パス)
 - [計画書籍](#計画書籍)

--- a/docs/paths/index.html
+++ b/docs/paths/index.html
@@ -1,0 +1,58 @@
+---
+layout: default
+title: 学習パス | IT Engineer Knowledge Architecture
+description: IT Engineer Knowledge Architecture の学習パス。正本カタログの bookIds と nextPathIds から生成します。
+permalink: /paths/
+---
+{% assign catalog = site.data.catalog %}
+{% assign books = catalog.books | sort: 'displayOrder' %}
+{% assign learning_paths = catalog.learningPaths %}
+
+<h1>学習パス</h1>
+
+<p>このページは <code>docs/_data/catalog.json</code> の <code>learningPaths</code> を正本として生成しています。各パスは catalog ID で書籍を参照するため、前提関係や次に進むパスを機械的に検証できます。</p>
+
+<nav aria-label="このページ内の移動" class="notice-box">
+  <a href="{{ '/books/' | relative_url }}">書籍一覧を見る</a> |
+  <a href="{{ '/' | relative_url }}">ホームへ戻る</a>
+</nav>
+
+<section class="catalog-summary" aria-label="学習パス集計">
+  <div class="summary-metric"><strong>{{ learning_paths | size }}</strong>学習パス</div>
+  <div class="summary-metric"><strong>{{ books | size }}</strong>catalog内書籍レコード</div>
+</section>
+
+<section class="path-grid" aria-label="学習パス一覧">
+{% for learning_path in learning_paths %}
+  <article id="{{ learning_path.id }}" class="path-card">
+    <h2>{{ learning_path.title.ja }}</h2>
+    {% if learning_path.title.en != learning_path.title.ja %}<p><strong>English:</strong> {{ learning_path.title.en }}</p>{% endif %}
+    <p>{{ learning_path.description.ja }}</p>
+
+    <h3>読む書籍</h3>
+    <ol class="book-sequence">
+      {% for book_id in learning_path.bookIds %}
+        {% for book in books %}
+          {% if book.id == book_id %}
+            <li>
+              {% if book.pagesUrl %}<a href="{{ book.pagesUrl }}">{{ book.title.ja }}</a>{% else %}{{ book.title.ja }}{% endif %}
+              <small>（<a href="{{ '/books/' | relative_url }}#{{ book.id }}">catalog</a> / {{ book.id }}）</small>
+            </li>
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+    </ol>
+
+    {% if learning_path.nextPathIds and learning_path.nextPathIds.size > 0 %}
+      <h3>次に進むパス</h3>
+      <ul>
+        {% for next_id in learning_path.nextPathIds %}
+          {% for next_path in learning_paths %}
+            {% if next_path.id == next_id %}<li><a href="#{{ next_path.id }}">{{ next_path.title.ja }}</a></li>{% endif %}
+          {% endfor %}
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </article>
+{% endfor %}
+</section>


### PR DESCRIPTION
## Summary

Refs #176.

This PR implements the next small Phase 3/4 foundation after the catalog source-of-truth PR. It keeps existing public URLs and the current long home page, while adding catalog-driven reader entry pages and an accessibility-oriented shared layout baseline.

## Changes

- Update the shared default layout with:
  - semantic `header` / `nav` / `main` / `footer`
  - skip link
  - one page-level H1 by changing the site title from header `h1` to a non-heading title element
  - focus-visible styling
  - `prefers-reduced-motion` handling
  - primary navigation with `aria-current`
  - canonical, hreflang, OGP, and JSON-LD metadata
  - table caption styling and scoped `.book-sequence` numbering instead of global `ol` counter styling
- Add `/books/` as a catalog-driven all-book card page generated from `docs/_data/catalog.json`.
  - JavaScript-disabled users still see all cards.
  - Vanilla JS filtering progressively enhances keyword/category/status/publication-scope filtering.
- Add `/paths/` as a catalog-driven learning path page generated from `learningPaths[].bookIds` and `nextPathIds`.
- Add a `/404.html` page with recovery links.
- Add README/docs/en entry links to `/books/`, `/paths/`, and `/publishing/`.
- Extend the validation workflow path filters and add a Jekyll site-build structure check for the new pages.

## Validation

- `npm run verify`
- `node scripts/validate-ux-registry.js`
- `npm audit --audit-level=moderate`
- `jekyll build --source docs --destination .../_site --trace`
- Built-site structure check for `/`, `/books/`, `/paths/`, `/404.html`, `/en/`:
  - each has exactly one `h1`
  - skip/main/nav markers exist
  - catalog/path markers render from `docs/_data/catalog.json`
- README-to-docs sync hash check matching `copy-readme.yml`
- Workflow YAML parse check
- Markdown `.md` link check matching the workflow logic
- `git diff --check`

## Notes

- This PR intentionally does not remove the existing long home-page catalog. Full README/site separation and home-page simplification remain later #176 phases.
- Full Playwright/axe coverage is still left for the dedicated E2E/accessibility phase.
