### PR TITLE
Add E2E accessibility checks and targeted sprint issues

### DIFF
--- a/.github/workflows/quality-sprint-reminder.yml
+++ b/.github/workflows/quality-sprint-reminder.yml
@@ -17,15 +17,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Create quality sprint issue (idempotent)
+      - name: Create targeted quality sprint issue (idempotent)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 - << 'PY'
-          import os, json, urllib.request, urllib.parse, urllib.error
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+          from collections import Counter, defaultdict
           from datetime import datetime, timezone
           from pathlib import Path
-          import time
 
           token = os.environ.get("GITHUB_TOKEN", "")
           if not token:
@@ -41,6 +46,7 @@ jobs:
               headers = {
                   "Authorization": f"Bearer {token}",
                   "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
                   "User-Agent": "itdojp-automation",
               }
               if data is not None:
@@ -64,36 +70,76 @@ jobs:
                       raise
               raise RuntimeError("github api retries exceeded")
 
-          today = datetime.now(timezone.utc).date().isoformat()
-          title = f"[Quality Sprint] {today}"
+          def search_open_quality_sprints():
+              q = f'repo:{repo_full_name} is:issue is:open in:title "[Quality Sprint]"'
+              return gh_api("GET", "/search/issues?q=" + urllib.parse.quote(q, safe=""))
 
-          # Idempotency: if an open issue with the same title exists, do nothing.
-          q = f'repo:{repo_full_name} is:issue is:open in:title "{title}"'
-          search = gh_api("GET", "/search/issues?q=" + urllib.parse.quote(q, safe=""))
-          if (search.get("total_count") or 0) > 0:
-              url = (search.get("items") or [{}])[0].get("html_url") or "-"
-              print(f"Skip: issue already exists: {url}")
+          # Idempotency: one open Quality Sprint issue is enough. Avoid piling up work.
+          existing = search_open_quality_sprints()
+          if (existing.get("total_count") or 0) > 0:
+              url = (existing.get("items") or [{}])[0].get("html_url") or "-"
+              print(f"Skip: an open quality sprint issue already exists: {url}")
               raise SystemExit(0)
 
-          catalog_path = Path("docs/_data/catalog.json")
-          catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+          catalog = json.loads(Path("docs/_data/catalog.json").read_text(encoding="utf-8"))
           books = catalog.get("books") or []
-          # Build checklist links from the catalog to avoid hard-coding Pages URL format.
-          # Phase 8 will narrow this to 2-4 selected books; this migration only
-          # switches the metadata source of truth.
-          repo_to_pages = {}
-          for meta in books:
-              if not isinstance(meta, dict) or meta.get("status") != "published":
-                  continue
-              if meta.get("countingGroup") != "main-lineup" or meta.get("countedInMainLineup") is not True:
-                  continue
-              repo = meta.get("repo")
-              if not repo:
-                  continue
-              pages = (meta.get("pagesUrl") or "").strip()
-              if repo not in repo_to_pages or (not repo_to_pages[repo] and pages):
-                  repo_to_pages[repo] = pages
+          candidates = [
+              b for b in books
+              if isinstance(b, dict)
+              and b.get("status") == "published"
+              and b.get("countingGroup") == "main-lineup"
+              and b.get("countedInMainLineup") is True
+              and b.get("repo")
+          ]
+          if not candidates:
+              raise SystemExit("No published main-lineup books found in docs/_data/catalog.json")
 
+          def review_sort_key(book):
+              # Null dates are oldest so books without a recorded review are selected first.
+              last_reviewed = book.get("lastReviewedAt") or "0000-00-00"
+              return (last_reviewed, book.get("displayOrder") or 9999, book.get("repo") or "")
+
+          candidates.sort(key=review_sort_key)
+          by_category = defaultdict(list)
+          for book in candidates:
+              by_category[book.get("category") or "uncategorized"].append(book)
+
+          oldest = candidates[0]
+          target_category = oldest.get("category") or "uncategorized"
+          selected = by_category[target_category][:4]
+
+          # Prefer one coherent category, but keep the issue actionable with 2-4 books.
+          if len(selected) < 2:
+              seen = {b.get("id") for b in selected}
+              for book in candidates:
+                  if book.get("id") not in seen:
+                      selected.append(book)
+                      seen.add(book.get("id"))
+                  if len(selected) >= 2:
+                      break
+          selected = selected[:4]
+
+          today = datetime.now(timezone.utc).date().isoformat()
+          title_category = target_category if len({b.get("category") for b in selected}) == 1 else "mixed"
+          title = f"[Quality Sprint] {today} {title_category}"
+
+          def text(value):
+              if value is None or value == "":
+                  return "未記録"
+              return str(value)
+
+          def title_ja(book):
+              title = book.get("title") or {}
+              if isinstance(title, dict):
+                  return title.get("ja") or title.get("en") or book.get("id") or book.get("repo")
+              return str(title)
+
+          def warning_notes(book):
+              notes = book.get("notes") or []
+              warnings = [note for note in notes if any(marker in note for marker in ("暫定", "要確認", "未記載", "要更新", "要レビュー"))]
+              return warnings
+
+          category_counts = Counter(b.get("category") or "uncategorized" for b in selected)
           lines = []
           lines.append("# 品質スプリント")
           lines.append("")
@@ -101,24 +147,47 @@ jobs:
           lines.append("")
           lines.append("## 目的")
           lines.append("- P2/P3（誤字脱字、表記ゆれ、軽微な構造不整合、外部リンク棚卸し等）を定期的に消化し、品質劣化を抑止する。")
+          lines.append("- 1回のスプリントは2〜4冊に限定し、レビュー・修正・検証・記録更新を完了させる。")
           lines.append("")
-          lines.append("## 実施ガイド（推奨）")
-          lines.append("- 1回のスプリントで2〜4冊を対象に小粒PRで対応（カテゴリ混在を避ける）。")
-          lines.append("- 根拠が必要な修正（仕様/EOL/非推奨等）は、公式ドキュメント等の参照を併記する。")
-          lines.append("- PRは Book QA を通過し、GitHub Pages で表示確認する。")
+          lines.append("## 今回の選定方針")
+          lines.append(f"- 選定日: {today} UTC")
+          lines.append("- 選定元: `docs/_data/catalog.json` の `status=published` / `countingGroup=main-lineup` / `countedInMainLineup=true`")
+          lines.append("- 優先度: `lastReviewedAt` が古い順。未記録は最古として扱う。")
+          lines.append("- カテゴリ: " + ", ".join(f"{cat}={count}冊" for cat, count in sorted(category_counts.items())))
           lines.append("")
-          lines.append("## 全書籍チェックリスト（対象選定・消し込み用）")
-          for repo in sorted(repo_to_pages.keys()):
-              name = repo.split("/", 1)[1]
-              pages = repo_to_pages.get(repo) or f"https://itdojp.github.io/{name}/"
-              lines.append(f"- [ ] {repo}（Pages: {pages}）")
-
+          lines.append("## 対象書籍チェックリスト")
+          for book in selected:
+              repo = book.get("repo")
+              pages = book.get("pagesUrl") or f"https://itdojp.github.io/{repo.split('/', 1)[1]}/"
+              warnings = warning_notes(book)
+              lines.append(f"- [ ] `{repo}` — {title_ja(book)}")
+              lines.append(f"  - Pages: {pages}")
+              lines.append(f"  - カテゴリ: `{book.get('category') or 'uncategorized'}`")
+              lines.append(f"  - 前回レビュー日: {text(book.get('lastReviewedAt'))}")
+              lines.append(f"  - レビュー状態: `{text(book.get('reviewStatus'))}`")
+              lines.append(f"  - 公開範囲: `{text(book.get('publicationScope'))}` / リポジトリ公開状態: `{text(book.get('repoVisibility'))}`")
+              if warnings:
+                  lines.append("  - 既知メモ/警告:")
+                  for warning in warnings:
+                      lines.append(f"    - {warning}")
+              else:
+                  lines.append("  - 既知メモ/警告: なし")
+          lines.append("")
+          lines.append("## 実施チェックリスト")
+          lines.append("- [ ] 対象リポジトリごとに既存Issue/PR/CI状態を確認する。")
+          lines.append("- [ ] 誤字脱字、表記ゆれ、軽微な構造不整合、リンク切れ、ビルド警告を確認する。")
+          lines.append("- [ ] 修正が必要な場合は、小粒PRで対応する。")
+          lines.append("- [ ] 根拠が必要な修正（仕様/EOL/非推奨等）は、公式ドキュメント等の参照をPR本文またはSource Notesへ記録する。")
+          lines.append("- [ ] 各PRで Book QA / CI / GitHub Pages 表示確認を完了する。")
+          lines.append("- [ ] 完了後、必要に応じて `docs/_data/catalog.json` の `lastReviewedAt` / `reviewStatus` / `reviewIssue` を更新するPRを作成する。")
+          lines.append("")
+          lines.append("## 完了条件")
+          lines.append("- 対象書籍の確認結果または修正PRがこのIssueに記録されている。")
+          lines.append("- 修正PRがある場合、CI成功・レビューコメント対応・Pages確認が完了している。")
+          lines.append("- 品質スプリントの記録更新方針（catalog更新PRを作る、または不要理由）が明示されている。")
           body = "\n".join(lines) + "\n"
 
-          issue_path = f"/repos/{repo_full_name}/issues"
           payload = {"title": title, "body": body}
-
-          # Labels may not exist in forks; only include when available.
           try:
               gh_api("GET", f"/repos/{repo_full_name}/labels/platform-wide")
               payload["labels"] = ["platform-wide"]
@@ -126,6 +195,6 @@ jobs:
               if e.code != 404:
                   raise
 
-          created = gh_api("POST", issue_path, payload)
+          created = gh_api("POST", f"/repos/{repo_full_name}/issues", payload)
           print("Created:", created.get("html_url"))
           PY

--- a/.github/workflows/validate-learning-paths.yml
+++ b/.github/workflows/validate-learning-paths.yml
@@ -19,6 +19,8 @@ on:
       - 'schemas/**'
       - 'scripts/**'
       - 'tests/fixtures/**'
+      - 'tests/e2e/**'
+      - 'playwright.config.mjs'
       - 'package.json'
       - 'package-lock.json'
   pull_request:
@@ -39,6 +41,8 @@ on:
       - 'schemas/**'
       - 'scripts/**'
       - 'tests/fixtures/**'
+      - 'tests/e2e/**'
+      - 'playwright.config.mjs'
       - 'package.json'
       - 'package-lock.json'
 
@@ -51,6 +55,14 @@ jobs:
       - name: チェックアウト
         uses: actions/checkout@v4
 
+      - name: Ruby設定
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Jekyllインストール
+        run: gem install jekyll -v 4.4.1
+
       - name: Node.js設定
         uses: actions/setup-node@v4
         with:
@@ -59,15 +71,27 @@ jobs:
       - name: npm依存関係確認
         run: npm ci
 
-      - name: カタログ正本・学習グラフ検証
+      - name: Playwrightブラウザインストール
+        run: npx playwright install --with-deps chromium
+
+      - name: カタログ・生成物・サイトE2E検証
         run: npm run verify
 
       - name: マークダウンリンクチェック
         run: |
           echo "🔗 マークダウンリンクチェック中..."
 
-          # 内部リンクの存在確認
-          find . -name "*.md" -exec grep -l "\[.*\](.*\.md)" {} \; | while read file; do
+          # 内部リンクの存在確認（依存関係・生成物は対象外）
+          find . \
+            -path './.git' -prune -o \
+            -path './node_modules' -prune -o \
+            -path './.site' -prune -o \
+            -path './test-results' -prune -o \
+            -path './playwright-report' -prune -o \
+            -name "*.md" -print | while read file; do
+            if ! grep -q "\[.*\](.*\.md)" "$file"; then
+              continue
+            fi
             echo "チェック中: $file"
             grep -oE "\[.*\]\([^)]*\.md[^)]*\)" "$file" | while read link; do
               path=$(echo "$link" | sed -E 's/.*\(([^)]*)\).*/\1/')
@@ -98,46 +122,6 @@ jobs:
           done
 
           echo "✅ リンクチェック通過"
-
-  build-site:
-    runs-on: ubuntu-latest
-    name: Jekyllサイト生成チェック
-
-    steps:
-      - name: チェックアウト
-        uses: actions/checkout@v4
-
-      - name: Ruby設定
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-
-      - name: Jekyllインストール
-        run: gem install jekyll -v 4.4.1
-
-      - name: Jekyll build
-        run: jekyll build --source docs --destination .site --baseurl /it-engineer-knowledge-architecture
-
-      - name: 主要ページ構造チェック
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-          root = Path('.site')
-          checks = {
-              'index.html': ['<main id="main-content"', '本文へスキップ', '/it-engineer-knowledge-architecture/books/', '/it-engineer-knowledge-architecture/paths/'],
-              'books/index.html': ['書籍一覧', 'data-book-card', '全 49 件', 'ai-agent-collaboration-book'],
-              'paths/index.html': ['学習パス', 'beginner-linux', 'book-sequence'],
-              '404.html': ['ページが見つかりません', '/it-engineer-knowledge-architecture/books/', '/it-engineer-knowledge-architecture/paths/'],
-              'en/index.html': ['English Catalog', '<html lang="en"'],
-          }
-          for rel, markers in checks.items():
-              text = (root / rel).read_text(encoding='utf-8')
-              h1_count = text.lower().count('<h1')
-              missing = [marker for marker in markers if marker not in text]
-              if h1_count != 1 or missing:
-                  raise SystemExit(f'{rel}: h1_count={h1_count}, missing={missing}')
-          print('site structure OK')
-          PY
 
   validate-yaml-structure:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,11 @@ tmp/
 .settings/
 .vscode/
 
+# Node dependencies
+node_modules/
+
 # Build and Data Output
 output/
+.site/
+test-results/
+playwright-report/

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -32,9 +32,6 @@
     <link rel="icon" type="image/png" sizes="48x48" href="{{ '/assets/images/itdo_logo_48x48_blue.png' | relative_url }}">
     <link rel="shortcut icon" type="image/png" href="{{ '/assets/images/itdo_logo_48x48_blue.png' | relative_url }}">
 
-    <!-- GitHub Pages default theme CSS -->
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-
     <!-- Custom styles -->
     <style>
         :root {
@@ -397,5 +394,15 @@
             <a href="mailto:knowledge@itdo.jp">Contact</a>
         </p>
     </footer>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('table').forEach(function (table) {
+          if (table.scrollWidth > table.clientWidth && !table.hasAttribute('tabindex')) {
+            table.setAttribute('tabindex', '0');
+          }
+        });
+      });
+    </script>
+
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,97 @@
   "packages": {
     "": {
       "name": "it-engineer-knowledge-architecture",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "devDependencies": {
+        "@axe-core/playwright": "4.12.1",
+        "@playwright/test": "1.61.1"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,13 @@
     "validate:catalog": "node scripts/validate-catalog.mjs",
     "validate:learning-graph": "node scripts/validate-learning-graph.mjs",
     "test:fixtures": "node scripts/test-catalog-fixtures.mjs",
-    "verify": "npm run validate:catalog && npm run validate:learning-graph && npm run check:generated && npm run test:fixtures"
+    "verify": "npm run verify:catalog && npm run build:site && npm run test:e2e",
+    "verify:catalog": "npm run validate:catalog && npm run validate:learning-graph && npm run check:generated && npm run test:fixtures",
+    "build:site": "rm -rf .site && jekyll build --source docs --destination .site/it-engineer-knowledge-architecture --baseurl /it-engineer-knowledge-architecture",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "4.12.1",
+    "@playwright/test": "1.61.1"
   }
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const basePath = '/it-engineer-knowledge-architecture';
+const port = process.env.PORT || 4177;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    trace: 'on-first-retry'
+  },
+  webServer: {
+    command: `npm run build:site && ruby -run -e httpd .site -p ${port}`,
+    url: `http://127.0.0.1:${port}${basePath}/`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000
+  },
+  projects: [
+    { name: 'chromium-desktop', use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 900 } } },
+    { name: 'chromium-tablet', use: { ...devices['iPad (gen 7)'], browserName: 'chromium' } },
+    { name: 'chromium-mobile', use: { ...devices['Pixel 5'], browserName: 'chromium' } }
+  ]
+});

--- a/tests/e2e/site.spec.mjs
+++ b/tests/e2e/site.spec.mjs
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const basePath = '/it-engineer-knowledge-architecture';
+const sitePath = (path) => `${basePath}${path}`;
+
+const pages = [
+  { path: '/', title: 'ITエンジニア知識アーキテクチャ' },
+  { path: '/books/', title: '書籍一覧' },
+  { path: '/paths/', title: '学習パス' },
+  { path: '/en/', title: 'English Catalog' },
+  { path: '/404.html', title: 'ページが見つかりません' }
+];
+
+test.describe('site structure and accessibility', () => {
+  for (const target of pages) {
+    test(`${target.path} has one h1, landmarks, and no axe violations`, async ({ page }) => {
+      await page.goto(sitePath(target.path));
+      await expect(page.locator('h1')).toHaveCount(1);
+      await expect(page.locator('h1')).toContainText(target.title);
+      await expect(page.locator('header')).toHaveCount(1);
+      await expect(page.locator('nav[aria-label="主要ナビゲーション"]')).toHaveCount(1);
+      await expect(page.locator('main#main-content')).toHaveCount(1);
+      await expect(page.locator('footer')).toHaveCount(1);
+
+      const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+      expect(accessibilityScanResults.violations).toEqual([]);
+    });
+  }
+
+  test('skip link becomes visible on keyboard focus', async ({ page }) => {
+    await page.goto(sitePath('/'));
+    const skipLink = page.locator('a.skip-link');
+    await skipLink.focus();
+    await expect(skipLink).toBeVisible();
+    await skipLink.press('Enter');
+    await expect(page.locator('#main-content')).toBeFocused();
+  });
+
+  test('Japanese and English entry links work under the Pages base path', async ({ page }) => {
+    await page.goto(sitePath('/'));
+    await page.getByRole('navigation', { name: '主要ナビゲーション' }).getByRole('link', { name: 'English', exact: true }).click();
+    await expect(page).toHaveURL(/\/it-engineer-knowledge-architecture\/en\/$/);
+    await expect(page.locator('h1')).toContainText('English Catalog');
+
+    await page.getByRole('navigation', { name: '主要ナビゲーション' }).getByRole('link', { name: 'ホーム', exact: true }).click();
+    await expect(page).toHaveURL(/\/it-engineer-knowledge-architecture\/$/);
+    await expect(page.locator('h1')).toContainText('ITエンジニア知識アーキテクチャ');
+  });
+});
+
+test.describe('catalog interactions', () => {
+  test('book catalog renders all records and filters progressively', async ({ page }) => {
+    await page.goto(sitePath('/books/'));
+    await expect(page.locator('[data-book-card]')).toHaveCount(49);
+    await expect(page.locator('#book-filter-result')).toContainText('全 49 件');
+
+    await page.locator('#book-filter-keyword').fill('Kubernetes');
+    await expect(page.locator('[data-book-card]:visible')).toHaveCount(3);
+    await expect(page.locator('#book-filter-result')).toContainText('3 / 49 件');
+
+    await page.locator('#book-filter-keyword').fill('');
+    await page.locator('#book-filter-scope').selectOption('free-preview');
+    await expect(page.locator('[data-book-card]:visible')).toHaveCount(1);
+    await expect(page.locator('[data-book-card]:visible')).toContainText('AIエージェント協働の仕事術');
+  });
+
+  test('book catalog remains fully visible without JavaScript', async ({ browser, baseURL }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+    await page.goto(`${baseURL}${sitePath('/books/')}`);
+    await expect(page.locator('[data-book-card]')).toHaveCount(49);
+    await expect(page.locator('[data-book-card]').first()).toBeVisible();
+    await context.close();
+  });
+
+  test('learning paths link to catalog anchors', async ({ page }) => {
+    await page.goto(sitePath('/paths/'));
+    await expect(page.locator('.path-card')).toHaveCount(7);
+    const firstCatalogLink = page.locator('.path-card').first().getByRole('link', { name: 'catalog' }).first();
+    await firstCatalogLink.click();
+    await expect(page).toHaveURL(/\/books\/#illustrated-linux-basics-book$/);
+    await expect(page.locator('#illustrated-linux-basics-book')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Refs #176

## Summary
- add Playwright + axe E2E/accessibility checks for the portfolio home, catalog, learning paths, English page, and 404 page across desktop/tablet/mobile Chromium profiles
- wire the validation workflow so `npm run verify` covers catalog validation, Jekyll build, and E2E/a11y checks; remove the duplicate build-only job
- redesign the scheduled Quality Sprint issue generator so it skips when any prior sprint issue is open, selects 2–4 oldest-review books preferably within one category, and records review metadata/warnings
- remove the stale default-theme CSS reference and make horizontally scrollable tables keyboard-focusable when needed

## Verification
- `npm ci`
- `npx playwright install chromium`
- `npm run verify` (30 Playwright/axe checks passed)
- `node scripts/validate-ux-registry.js`
- `npm audit --audit-level=moderate`
- JSON/YAML parse check
- Markdown `.md` link check
- `git diff --check`

## Notes
- Quality Sprint target selection is catalog-driven. With the current catalog state, the next generated sprint targets the two `beginner-track` books whose `lastReviewedAt` is still unrecorded.
- The workflow installs only Chromium because all Playwright projects are explicitly Chromium profiles.
