### PR TITLE
Pages build情報とpost-deploy smokeを追加する

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - 'docs/**'
+      - 'scripts/write-build-info.mjs'
+      - 'scripts/smoke-production.mjs'
       - '.github/workflows/deploy-pages.yml'
   workflow_dispatch: {}
 
@@ -18,11 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
+    name: Build Pages artifact
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,11 +42,75 @@ jobs:
       - name: Build site
         run: jekyll build --source docs --destination _site --baseurl /it-engineer-knowledge-architecture
 
-      - name: Upload artifact
+      - name: Add deployment build information
+        run: node scripts/write-build-info.mjs _site/build-info.json
+
+      - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
+  deploy:
+    name: Deploy Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  post-deploy-smoke:
+    name: Production smoke
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout deployed revision
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Verify production deployment
+        id: smoke
+        continue-on-error: true
+        run: |
+          node scripts/smoke-production.mjs \
+            --base-url "${{ needs.deploy.outputs.page_url }}" \
+            --expected-sha "${{ github.sha }}" \
+            --max-attempts 8 \
+            --retry-delay-ms 3000 \
+            --timeout-ms 15000 \
+            --report-json tmp/production-smoke/report.json \
+            --report-markdown tmp/production-smoke/report.md
+
+      - name: Add smoke result to job summary
+        if: always()
+        run: |
+          if [[ -f tmp/production-smoke/report.md ]]; then
+            cat tmp/production-smoke/report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'Production smoke did not create a report.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload production smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: tmp/production-smoke
+          if-no-files-found: error
+
+      - name: Enforce production smoke result
+        if: always() && steps.smoke.outcome != 'success'
+        run: |
+          echo 'Production smoke failed. See the job summary and artifact.' >&2
+          exit 1

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "validate:catalog": "node scripts/validate-catalog.mjs",
     "validate:learning-graph": "node scripts/validate-learning-graph.mjs",
     "test:fixtures": "node scripts/test-catalog-fixtures.mjs",
-    "verify": "npm run verify:catalog && npm run build:site && npm run test:e2e",
+    "verify": "npm run verify:catalog && npm run test:production-smoke && npm run build:site && npm run test:e2e",
     "verify:catalog": "npm run validate:catalog && npm run validate:learning-graph && npm run check:generated && npm run test:fixtures",
     "build:site": "rm -rf .site && jekyll build --source docs --destination .site/it-engineer-knowledge-architecture --baseurl /it-engineer-knowledge-architecture",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:production-smoke": "node --test tests/smoke-production.test.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/scripts/smoke-production.mjs
+++ b/scripts/smoke-production.mjs
@@ -1,0 +1,263 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_BASE_URL = 'https://itdojp.github.io/it-engineer-knowledge-architecture/';
+const DEFAULT_EXPECTED_SHA = '';
+const OLD_HOME_MARKERS = [
+  'Building Your Tech Career, One Book at a Time',
+  'id="日本語概要"',
+  'id="専門分野別学習パス"'
+];
+
+const HTML_TARGETS = [
+  { path: '', label: '/', h1: 'ITエンジニア知識アーキテクチャ' },
+  { path: 'books/', label: '/books/', h1: '書籍一覧', cardCount: 49 },
+  { path: 'paths/', label: '/paths/', h1: '学習パス', pathCount: 7 },
+  { path: 'en/', label: '/en/', h1: 'English Catalog' },
+  { path: '404.html', label: '/404.html', h1: 'ページが見つかりません' }
+];
+
+const REQUIRED_ROOT_LINKS = ['books/', 'paths/', 'en/'];
+
+function parseInteger(value, fallback, minimum = 1) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed >= minimum ? parsed : fallback;
+}
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value || DEFAULT_BASE_URL);
+  if (!url.pathname.endsWith('/')) url.pathname += '/';
+  return url.toString();
+}
+
+function parseArgs(argv, env = process.env) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith('--')) throw new Error(`Unknown argument: ${key}`);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) throw new Error(`Missing value for ${key}`);
+    values[key.slice(2)] = value;
+    index += 1;
+  }
+  return {
+    baseUrl: normalizeBaseUrl(values['base-url'] || env.SMOKE_BASE_URL || DEFAULT_BASE_URL),
+    expectedSha: values['expected-sha'] || env.SMOKE_EXPECTED_SHA || DEFAULT_EXPECTED_SHA,
+    maxAttempts: parseInteger(values['max-attempts'] || env.SMOKE_MAX_ATTEMPTS, 8),
+    retryDelayMs: parseInteger(values['retry-delay-ms'] || env.SMOKE_RETRY_DELAY_MS, 3_000, 0),
+    timeoutMs: parseInteger(values['timeout-ms'] || env.SMOKE_TIMEOUT_MS, 15_000),
+    reportJson: values['report-json'] || env.SMOKE_REPORT_JSON || 'tmp/production-smoke/report.json',
+    reportMarkdown: values['report-markdown'] || env.SMOKE_REPORT_MARKDOWN || 'tmp/production-smoke/report.md'
+  };
+}
+
+function stripHtml(value) {
+  return value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractH1(html) {
+  const match = html.match(/<h1(?:\s[^>]*)?>([\s\S]*?)<\/h1>/i);
+  return match ? stripHtml(match[1]) : null;
+}
+
+function markerSummary(html) {
+  return {
+    h1: extractH1(html),
+    hasNavigation: /<nav\b[^>]*aria-label=["']主要ナビゲーション["']/i.test(html),
+    hasMain: /<main\b[^>]*id=["']main-content["']/i.test(html),
+    oldMarkers: OLD_HOME_MARKERS.filter((marker) => html.includes(marker))
+  };
+}
+
+async function fetchWithTimeout(fetchImpl, url, timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, {
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+        Pragma: 'no-cache'
+      },
+      redirect: 'follow',
+      signal: controller.signal
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function cacheBustedUrl(baseUrl, path, attempt, now) {
+  const url = new URL(path, baseUrl);
+  url.searchParams.set('deployment_check', `${now()}-${attempt}`);
+  return url;
+}
+
+async function checkHtmlTarget(fetchImpl, config, target, attempt, now) {
+  const url = cacheBustedUrl(config.baseUrl, target.path, attempt, now);
+  const result = { label: target.label, url: url.toString(), status: null, errors: [], markers: {} };
+  try {
+    const response = await fetchWithTimeout(fetchImpl, url, config.timeoutMs);
+    result.status = response.status;
+    const html = await response.text();
+    result.markers = markerSummary(html);
+    if (response.status !== 200) result.errors.push(`HTTP status ${response.status}, expected 200`);
+    if (!result.markers.h1?.includes(target.h1)) {
+      result.errors.push(`H1 ${JSON.stringify(result.markers.h1)}, expected text ${JSON.stringify(target.h1)}`);
+    }
+    if (!result.markers.hasNavigation) result.errors.push('common navigation was not found');
+    if (!result.markers.hasMain) result.errors.push('main#main-content was not found');
+    if (target.label === '/' && result.markers.oldMarkers.length > 0) {
+      result.errors.push(`old home marker remains: ${result.markers.oldMarkers.join(', ')}`);
+    }
+    if (target.cardCount !== undefined) {
+      const count = (html.match(/\bdata-book-card(?:\s|=|>)/g) || []).length;
+      result.markers.cardCount = count;
+      if (count !== target.cardCount) result.errors.push(`catalog cards ${count}, expected ${target.cardCount}`);
+    }
+    if (target.pathCount !== undefined) {
+      const count = (html.match(/<article\b[^>]*class=["'][^"']*\bpath-card\b[^"']*["']/gi) || []).length;
+      result.markers.pathCount = count;
+      if (count !== target.pathCount) result.errors.push(`learning paths ${count}, expected ${target.pathCount}`);
+    }
+    if (target.label === '/') {
+      const basePath = new URL(config.baseUrl).pathname;
+      for (const path of REQUIRED_ROOT_LINKS) {
+        const expectedHref = `${basePath}${path}`.replace(/\/{2,}/g, '/');
+        if (!html.includes(`href="${expectedHref}"`) && !html.includes(`href='${expectedHref}'`)) {
+          result.errors.push(`major link missing or outside Pages base path: ${expectedHref}`);
+        }
+      }
+    }
+  } catch (error) {
+    result.errors.push(error instanceof Error ? `${error.name}: ${error.message}` : String(error));
+  }
+  return result;
+}
+
+async function checkBuildInfo(fetchImpl, config, attempt, now) {
+  const url = cacheBustedUrl(config.baseUrl, 'build-info.json', attempt, now);
+  const result = { label: '/build-info.json', url: url.toString(), status: null, errors: [], markers: {}, buildInfo: null };
+  try {
+    const response = await fetchWithTimeout(fetchImpl, url, config.timeoutMs);
+    result.status = response.status;
+    const body = await response.text();
+    if (response.status !== 200) result.errors.push(`HTTP status ${response.status}, expected 200`);
+    try {
+      result.buildInfo = JSON.parse(body);
+    } catch {
+      result.errors.push('response is not valid JSON');
+      return result;
+    }
+    const actualSha = result.buildInfo?.sha;
+    result.markers.actualSha = actualSha || null;
+    if (actualSha !== config.expectedSha) {
+      result.errors.push(`build SHA ${JSON.stringify(actualSha)}, expected ${JSON.stringify(config.expectedSha)}`);
+    }
+    if (result.buildInfo?.repository !== 'itdojp/it-engineer-knowledge-architecture') {
+      result.errors.push(`unexpected repository ${JSON.stringify(result.buildInfo?.repository)}`);
+    }
+    if (!result.buildInfo?.builtAt || Number.isNaN(Date.parse(result.buildInfo.builtAt))) {
+      result.errors.push('builtAt is missing or invalid');
+    }
+  } catch (error) {
+    result.errors.push(error instanceof Error ? `${error.name}: ${error.message}` : String(error));
+  }
+  return result;
+}
+
+function toMarkdown(report) {
+  const lines = [
+    '# Production smoke report',
+    '',
+    `- Result: **${report.ok ? 'PASS' : 'FAIL'}**`,
+    `- Base URL: ${report.baseUrl}`,
+    `- Expected SHA: \`${report.expectedSha}\``,
+    `- Actual SHA: \`${report.actualSha || 'unknown'}\``,
+    `- Attempts: ${report.attempts}`,
+    '',
+    '| Path | Status | Result | Markers |',
+    '|---|---:|---|---|'
+  ];
+  for (const endpoint of report.endpoints) {
+    const markers = JSON.stringify(endpoint.markers || {}).replaceAll('|', '\\|');
+    lines.push(`| ${endpoint.label} | ${endpoint.status ?? '-'} | ${endpoint.errors.length === 0 ? 'PASS' : endpoint.errors.join('; ')} | \`${markers}\` |`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function writeReport(report, config) {
+  for (const [path, content] of [
+    [config.reportJson, `${JSON.stringify(report, null, 2)}\n`],
+    [config.reportMarkdown, toMarkdown(report)]
+  ]) {
+    const target = resolve(path);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, content, 'utf8');
+  }
+}
+
+export async function runProductionSmoke(inputConfig, dependencies = {}) {
+  const config = {
+    baseUrl: normalizeBaseUrl(inputConfig.baseUrl),
+    expectedSha: inputConfig.expectedSha,
+    maxAttempts: inputConfig.maxAttempts ?? 8,
+    retryDelayMs: inputConfig.retryDelayMs ?? 3_000,
+    timeoutMs: inputConfig.timeoutMs ?? 15_000,
+    reportJson: inputConfig.reportJson ?? 'tmp/production-smoke/report.json',
+    reportMarkdown: inputConfig.reportMarkdown ?? 'tmp/production-smoke/report.md'
+  };
+  if (!/^[0-9a-f]{40}$/i.test(config.expectedSha || '')) {
+    throw new Error('expected SHA must be a 40-character commit SHA');
+  }
+  const fetchImpl = dependencies.fetchImpl || globalThis.fetch;
+  const sleep = dependencies.sleep || ((ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms)));
+  const now = dependencies.now || Date.now;
+  let report;
+  for (let attempt = 1; attempt <= config.maxAttempts; attempt += 1) {
+    const endpoints = [];
+    for (const target of HTML_TARGETS) {
+      endpoints.push(await checkHtmlTarget(fetchImpl, config, target, attempt, now));
+    }
+    endpoints.push(await checkBuildInfo(fetchImpl, config, attempt, now));
+    const ok = endpoints.every((endpoint) => endpoint.errors.length === 0);
+    report = {
+      ok,
+      baseUrl: config.baseUrl,
+      expectedSha: config.expectedSha,
+      actualSha: endpoints.at(-1)?.buildInfo?.sha || null,
+      attempts: attempt,
+      checkedAt: new Date(now()).toISOString(),
+      endpoints
+    };
+    if (ok) break;
+    if (attempt < config.maxAttempts) {
+      const delay = Math.min(config.retryDelayMs * 2 ** (attempt - 1), 30_000);
+      await sleep(delay);
+    }
+  }
+  await writeReport(report, config);
+  return report;
+}
+
+export { parseArgs, toMarkdown };
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    const config = parseArgs(process.argv.slice(2));
+    const report = await runProductionSmoke(config);
+    console.log(toMarkdown(report));
+    if (!report.ok) process.exitCode = 1;
+  } catch (error) {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/write-build-info.mjs
+++ b/scripts/write-build-info.mjs
@@ -1,0 +1,40 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+export function createBuildInfo(env = process.env, now = new Date()) {
+  const sha = env.GITHUB_SHA;
+  if (!SHA_PATTERN.test(sha || '')) {
+    throw new Error('GITHUB_SHA must be a 40-character commit SHA');
+  }
+
+  return {
+    repository: env.GITHUB_REPOSITORY || 'itdojp/it-engineer-knowledge-architecture',
+    sha,
+    ref: env.GITHUB_REF || 'refs/heads/main',
+    runId: String(env.GITHUB_RUN_ID || ''),
+    runAttempt: String(env.GITHUB_RUN_ATTEMPT || ''),
+    builtAt: now.toISOString()
+  };
+}
+
+export async function writeBuildInfo(outputPath, env = process.env, now = new Date()) {
+  const target = resolve(outputPath);
+  await mkdir(dirname(target), { recursive: true });
+  const info = createBuildInfo(env, now);
+  await writeFile(target, `${JSON.stringify(info, null, 2)}\n`, 'utf8');
+  return info;
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  const outputPath = process.argv[2] || '_site/build-info.json';
+  try {
+    const info = await writeBuildInfo(outputPath);
+    console.log(`build-info.json: ${outputPath} (${info.sha})`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tests/smoke-production.test.mjs
+++ b/tests/smoke-production.test.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { runProductionSmoke } from '../scripts/smoke-production.mjs';
+import { createBuildInfo, writeBuildInfo } from '../scripts/write-build-info.mjs';
+
+const SHA = '1234567890abcdef1234567890abcdef12345678';
+const OTHER_SHA = 'abcdef1234567890abcdef1234567890abcdef12';
+const basePath = '/it-engineer-knowledge-architecture/';
+
+function page(title, content = '') {
+  return `<!doctype html><html><body><nav aria-label="主要ナビゲーション"></nav><main id="main-content"><h1>${title}</h1>${content}</main></body></html>`;
+}
+
+async function startSite(options = {}) {
+  let transientFailures = options.transientFailures || 0;
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url, 'http://localhost');
+    const relative = url.pathname.startsWith(basePath) ? url.pathname.slice(basePath.length) : null;
+    if (options.delayPath === relative) await new Promise((resolve) => setTimeout(resolve, options.delayMs || 100));
+    const forcedStatus = options.statuses?.[relative];
+    if (forcedStatus) {
+      response.writeHead(forcedStatus, { 'Content-Type': 'text/plain' });
+      response.end(`forced ${forcedStatus}`);
+      return;
+    }
+    if (options.transientPath === relative && transientFailures > 0) {
+      transientFailures -= 1;
+      response.writeHead(503, { 'Content-Type': 'text/plain' });
+      response.end('deployment is still propagating');
+      return;
+    }
+    const routes = {
+      '': page(
+        'ITエンジニア知識アーキテクチャ',
+        `<a href="${basePath}books/">books</a><a href="${basePath}paths/">paths</a><a href="${basePath}en/">en</a>${options.oldMarker || ''}`
+      ),
+      'books/': page('書籍一覧', '<article data-book-card></article>'.repeat(options.cardCount ?? 49)),
+      'paths/': page('学習パス', '<article class="path-card"></article>'.repeat(options.pathCount ?? 7)),
+      'en/': page('English Catalog'),
+      '404.html': page('ページが見つかりません')
+    };
+    if (relative === 'build-info.json') {
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({
+        repository: 'itdojp/it-engineer-knowledge-architecture',
+        sha: options.sha || SHA,
+        ref: 'refs/heads/main',
+        runId: '100',
+        runAttempt: '1',
+        builtAt: '2026-07-11T00:00:00.000Z'
+      }));
+      return;
+    }
+    if (relative !== null && routes[relative]) {
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      response.end(routes[relative]);
+      return;
+    }
+    response.writeHead(404, { 'Content-Type': 'text/plain' });
+    response.end('not found');
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}${basePath}`,
+    close: () => new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  };
+}
+
+async function withSite(options, callback) {
+  const site = await startSite(options);
+  const output = await mkdtemp(join(process.cwd(), '.smoke-test-'));
+  try {
+    return await callback(site, output);
+  } finally {
+    await site.close();
+    await rm(output, { recursive: true, force: true });
+  }
+}
+
+function config(site, output, overrides = {}) {
+  return {
+    baseUrl: site.baseUrl,
+    expectedSha: SHA,
+    maxAttempts: 1,
+    retryDelayMs: 0,
+    timeoutMs: 500,
+    reportJson: join(output, 'report.json'),
+    reportMarkdown: join(output, 'report.md'),
+    ...overrides
+  };
+}
+
+test('build info uses workflow SHA and writes only to the requested artifact path', async () => {
+  const output = await mkdtemp(join(process.cwd(), '.build-info-test-'));
+  try {
+    const env = {
+      GITHUB_REPOSITORY: 'itdojp/it-engineer-knowledge-architecture',
+      GITHUB_SHA: SHA,
+      GITHUB_REF: 'refs/heads/main',
+      GITHUB_RUN_ID: '42',
+      GITHUB_RUN_ATTEMPT: '3'
+    };
+    const expected = createBuildInfo(env, new Date('2026-07-11T01:02:03Z'));
+    const target = join(output, 'site', 'build-info.json');
+    await writeBuildInfo(target, env, new Date('2026-07-11T01:02:03Z'));
+    assert.deepEqual(JSON.parse(await readFile(target, 'utf8')), expected);
+    assert.equal(expected.sha, SHA);
+    assert.equal(expected.builtAt, '2026-07-11T01:02:03.000Z');
+  } finally {
+    await rm(output, { recursive: true, force: true });
+  }
+});
+
+test('production smoke passes all required pages and writes reports', async () => {
+  await withSite({}, async (site, output) => {
+    const report = await runProductionSmoke(config(site, output));
+    assert.equal(report.ok, true);
+    assert.equal(report.actualSha, SHA);
+    assert.equal(report.endpoints.length, 6);
+    assert.equal(JSON.parse(await readFile(join(output, 'report.json'), 'utf8')).ok, true);
+    assert.match(await readFile(join(output, 'report.md'), 'utf8'), /Result: \*\*PASS\*\*/);
+  });
+});
+
+test('production smoke detects a SHA mismatch', async () => {
+  await withSite({ sha: OTHER_SHA }, async (site, output) => {
+    const report = await runProductionSmoke(config(site, output));
+    assert.equal(report.ok, false);
+    assert.equal(report.actualSha, OTHER_SHA);
+    assert.match(report.endpoints.at(-1).errors.join('\n'), new RegExp(`${OTHER_SHA}.*${SHA}`));
+  });
+});
+
+test('production smoke retries a transient deployment response with backoff', async () => {
+  await withSite({ transientPath: 'build-info.json', transientFailures: 1 }, async (site, output) => {
+    const delays = [];
+    const report = await runProductionSmoke(
+      config(site, output, { maxAttempts: 2, retryDelayMs: 25 }),
+      { sleep: async (delay) => delays.push(delay) }
+    );
+    assert.equal(report.ok, true);
+    assert.equal(report.attempts, 2);
+    assert.deepEqual(delays, [25]);
+  });
+});
+
+test('production smoke detects a required page returning 404', async () => {
+  await withSite({ statuses: { 'books/': 404 } }, async (site, output) => {
+    const report = await runProductionSmoke(config(site, output));
+    assert.equal(report.ok, false);
+    const books = report.endpoints.find((endpoint) => endpoint.label === '/books/');
+    assert.equal(books.status, 404);
+    assert.match(books.errors.join('\n'), /HTTP status 404/);
+  });
+});
+
+test('production smoke detects the legacy README home marker', async () => {
+  await withSite({ oldMarker: 'Building Your Tech Career, One Book at a Time' }, async (site, output) => {
+    const report = await runProductionSmoke(config(site, output));
+    assert.equal(report.ok, false);
+    const home = report.endpoints.find((endpoint) => endpoint.label === '/');
+    assert.match(home.errors.join('\n'), /old home marker remains/);
+  });
+});
+
+test('production smoke reports request timeouts', async () => {
+  await withSite({ delayPath: 'paths/', delayMs: 150 }, async (site, output) => {
+    const report = await runProductionSmoke(config(site, output, { timeoutMs: 20 }));
+    assert.equal(report.ok, false);
+    const paths = report.endpoints.find((endpoint) => endpoint.label === '/paths/');
+    assert.match(paths.errors.join('\n'), /AbortError|aborted|abort/i);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #181の第1段階として、Pages artifactへコミット情報を埋め込み、デプロイ完了後に本番URLとデプロイSHAを検証します。

## 調査前提

- Pages API: `build_type=workflow`
- 調査時main / latest successful deployment: `73f5eb1fce0496aa3446738c9f98cb8e816687fb`で一致
- 現在の主要公開URLは200で、新しい読者向けホームを配信
- `/build-info.json`は未実装で404

調査証跡: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/181#issuecomment-4942734768

## 変更内容

- Jekyll build後の`_site/build-info.json`生成
  - `sha`は`GITHUB_SHA`
  - repository/ref/run ID/attempt/builtAtを記録
  - Pages artifactだけに含め、ソースへ生成物をcommitしない
- `scripts/smoke-production.mjs`
  - `/`, `/books/`, `/paths/`, `/en/`, `/404.html`, `/build-info.json`
  - status、H1、共通nav、`main#main-content`
  - catalog card 49件、learning path 7件
  - Pages base path配下の主要リンク
  - 旧README markerの不在
  - 公開SHAとexpected SHAの一致
  - no-cache/cache-busting、timeout、指数backoff、最大試行回数
  - JSON/Markdown reportと失敗診断
- Deploy Pagesをbuild/deploy/post-deploy smokeの3 jobへ分離
- smoke reportをStep SummaryとActions artifactへ保存
- smoke失敗時はDeploy Pages workflowをfailureにする

## テスト

- `npm ci`: 0 vulnerabilities
- `npm run test:production-smoke`: 7 tests passed
  - 正常系
  - SHA不一致
  - transient response/retry
  - 404
  - 旧marker
  - timeout
  - build-info生成
- `npm run verify`: 30 Playwright/axe testsを含め成功
- actionlint 1.7.12: 成功
- Ruby YAML parse: 成功
- `git diff --check`: 成功

## 後続PR

定期ドリフト検知、重複しないalert Issue、復旧時close、READMEと`docs/publishing/`運用手順は、本PRの公開`build-info.json`を前提に別PRで追加します。

Refs #181
