### PR TITLE
feat: add Pages drift monitoring and recovery runbook

### DIFF
--- a/.github/workflows/pages-drift-check.yml
+++ b/.github/workflows/pages-drift-check.yml
@@ -1,0 +1,63 @@
+name: Pages drift check
+
+on:
+  schedule:
+    - cron: '30 0 * * *'
+  workflow_dispatch:
+    inputs:
+      expected_sha_override:
+        description: '異常系の動作確認専用。通常は空欄。40文字の期待SHAを指定する'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  deployments: read
+  issues: write
+
+concurrency:
+  group: pages-drift-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Compare source, deployment, and production
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PAGES_BASE_URL: https://itdojp.github.io/it-engineer-knowledge-architecture/
+      EXPECTED_SHA_OVERRIDE: ${{ inputs.expected_sha_override || '' }}
+      DRIFT_REPORT_JSON: tmp/pages-drift/report.json
+      DRIFT_REPORT_MARKDOWN: tmp/pages-drift/report.md
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Pages drift and manage alert
+        id: drift
+        continue-on-error: true
+        run: node scripts/check-pages-drift.mjs
+
+      - name: Add result to job summary
+        if: always()
+        run: |
+          if [[ -f "$DRIFT_REPORT_MARKDOWN" ]]; then
+            cat "$DRIFT_REPORT_MARKDOWN" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'Pages drift check did not create a report.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pages-drift-${{ github.run_id }}-${{ github.run_attempt }}
+          path: tmp/pages-drift
+          if-no-files-found: error
+
+      - name: Enforce drift result
+        if: always() && steps.drift.outcome != 'success'
+        run: |
+          echo 'Pages drift or monitoring failure detected. See the job summary, artifact, and alert Issue.' >&2
+          exit 1

--- a/README.md
+++ b/README.md
@@ -62,11 +62,15 @@ jekyll build --source docs --destination .site --baseurl /it-engineer-knowledge-
 ```
 
 GitHub Pages 用の本番デプロイは `.github/workflows/deploy-pages.yml` で Actions artifact として行います。
+`main` の更新後は `/build-info.json` を含む本番スモークテストを実行し、公開物がデプロイ対象commitと一致することを確認します。さらに `.github/workflows/pages-drift-check.yml` が毎日、default branch、最新の成功済みPages deployment、公開中のbuild情報を比較します。不整合時は単一のAlert Issueを作成または更新し、復旧時に証跡を残してクローズします。
+
+Pagesの公開方式は **GitHub Actions**（API上の `build_type: workflow`）に固定します。`main` や `docs/` を直接公開するbranch deploymentへ戻してはいけません。初期設定、確認コマンド、障害対応は[Pagesデプロイ運用Runbook](docs/publishing/pages-deployment-runbook.md)を参照してください。
 
 ## Workflow運用方針
 
 - PRでは `npm run verify` と Jekyll build の構造チェックを通す。
 - 定期実行Workflowは、実行時点の動的データをartifactまたはIssue通知として扱い、定期実行だけを理由に `main` へ自動コミットしない。
+- Pages drift確認はソースを変更・コミットせず、実行サマリ、artifact、重複しないAlert Issueだけを更新する。
 - Star数、Open Issue/PR数、リポジトリ更新日時などの時点依存データは正本へ保存しない。
 
 ## コントリビューション

--- a/docs/publishing/index.md
+++ b/docs/publishing/index.md
@@ -15,6 +15,7 @@ description: 書籍シリーズの体裁・構成・運用の標準
 - [運用プレイブック（book-formatter更新の横展開）](./operations-playbook.md)
 - [運用ダッシュボード](./operations-dashboard.html)
 - [品質スプリント運用](./quality-sprint.md)
+- [GitHub Pagesデプロイ運用Runbook](./pages-deployment-runbook.md)
 - [フォント可読性 E2E 確認ログ（2026-05-24）](./font-readability-check-2026-05-24.html)
 - [Sidebar TOC overlap 調査ログ（2026-06-07）](./sidebar-overlap-investigation-2026-06-07.html)
 - [新規書籍クイックスタート](./new-book-quickstart.md)

--- a/docs/publishing/pages-deployment-runbook.md
+++ b/docs/publishing/pages-deployment-runbook.md
@@ -1,0 +1,89 @@
+---
+layout: default
+title: GitHub Pagesデプロイ運用Runbook
+description: Actions artifact方式の設定、デプロイ検証、drift検知と復旧手順
+---
+
+# GitHub Pagesデプロイ運用Runbook
+
+## 運用原則
+
+- GitHub Pagesの公開元はGitHub Actions（Pages APIの `build_type: workflow`）とする。
+- `.github/workflows/deploy-pages.yml` が生成したartifactだけを公開する。
+- `main`、`docs/`、`gh-pages` などを直接公開するbranch deploymentへ戻さない。
+- Workflowは動的な確認結果をソースへ書き戻さず、`main` へbot commitを作らない。
+- 公開物のcommitはartifact内の `/build-info.json` を正本として確認する。`docs/` にはこのファイルを置かない。
+
+## 一度だけ行うPages設定
+
+通常は変更不要である。新規作成または設定復旧時に、リポジトリ管理者がGitHubの **Settings > Pages > Build and deployment > Source** を **GitHub Actions** に設定する。
+
+CLIで現在値を確認する。
+
+```bash
+gh api repos/itdojp/it-engineer-knowledge-architecture/pages \
+  --jq '{build_type: .build_type, status: .status, html_url: .html_url}'
+```
+
+期待値は `build_type: workflow` である。`legacy` の場合はbranch deploymentであり、運用要件を満たさない。UIでGitHub Actionsへ戻してから、Deploy Pagesを手動実行する。
+
+```bash
+gh workflow run deploy-pages.yml --repo itdojp/it-engineer-knowledge-architecture
+```
+
+## 通常のデプロイと検証
+
+`main` の `docs/**`、デプロイWorkflow、build情報生成、または本番スモークの変更でDeploy Pagesが起動する。処理は次の3 jobで構成する。
+
+1. Jekyllをbuildし、`_site/build-info.json` を追加してPages artifactを作る。
+2. artifactを `github-pages` environmentへデプロイする。
+3. deploymentが返した `page_url` に対して本番スモークを実行する。
+
+本番スモークは `/`、`/books/`、`/paths/`、`/en/`、`/404.html`、`/build-info.json` のHTTP状態、主要見出し、共通ナビゲーション、`main#main-content`、書籍49件、学習パス7件、base path内リンク、旧トップページmarkerの不在、期待SHAを検証する。キャッシュ回避query、timeout、指数backoff付きretryを用いる。結果はjob summaryとartifactに残り、不一致ならWorkflowを失敗させる。
+
+手動で公開SHAを確認する。
+
+```bash
+curl --fail --silent --show-error \
+  'https://itdojp.github.io/it-engineer-knowledge-architecture/build-info.json?manual_check=1' | jq
+git ls-remote https://github.com/itdojp/it-engineer-knowledge-architecture.git refs/heads/main
+```
+
+## 定期drift確認
+
+`.github/workflows/pages-drift-check.yml` は毎日および手動で実行し、次を比較する。
+
+1. GitHub APIで取得したdefault branchの最新commit SHA
+2. 最新の成功済み `github-pages` deployment SHA
+3. 公開 `/build-info.json` のSHA
+4. 本番スモークの全endpoint・marker検証結果
+
+一致時は実行サマリとartifactだけを残す。不一致または公開異常時はタイトル `[Alert][Pages Drift] 公開サイトのデプロイ不整合` のIssueを1件だけ作る。未復旧の再検知では同じIssueへ証跡を追記し、重複Issueを作らない。復旧時は同じIssueへ復旧結果を追記してクローズする。
+
+通常の手動確認は入力なしで実行する。
+
+```bash
+gh workflow run pages-drift-check.yml --repo itdojp/it-engineer-knowledge-architecture
+```
+
+`expected_sha_override` は監視機能の異常系試験専用である。通常運用では指定しない。異常系試験後は入力なしで再実行し、公開状態の一致とAlert Issueの自動クローズを確認する。
+
+## 不整合時の調査順序
+
+1. Alert Issue、失敗したWorkflowのjob summary、`pages-drift-*` artifactを確認する。
+2. Pages APIの `build_type` が `workflow` か確認する。
+3. Deploy Pagesの最新実行でbuild、deploy、Production smokeのどこが失敗したか確認する。
+4. default branch SHA、deployment SHA、公開build-info SHAを比較する。
+5. deploymentだけが古い場合はDeploy Pagesを再実行する。公開物の内容異常なら原因修正をPRで行う。
+6. 入力なしのPages drift checkを再実行し、復旧コメントとAlert Issueのクローズを確認する。
+
+```bash
+gh run list --repo itdojp/it-engineer-knowledge-architecture \
+  --workflow deploy-pages.yml --limit 10
+gh run list --repo itdojp/it-engineer-knowledge-architecture \
+  --workflow pages-drift-check.yml --limit 10
+gh api repos/itdojp/it-engineer-knowledge-architecture/deployments \
+  --method GET -f environment=github-pages -f per_page=10
+```
+
+branch deploymentへの切り替え、監視Workflowによるソース修正、失敗を無視する再実行は復旧策に含めない。

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "validate:catalog": "node scripts/validate-catalog.mjs",
     "validate:learning-graph": "node scripts/validate-learning-graph.mjs",
     "test:fixtures": "node scripts/test-catalog-fixtures.mjs",
-    "verify": "npm run verify:catalog && npm run test:production-smoke && npm run build:site && npm run test:e2e",
+    "verify": "npm run verify:catalog && npm run test:production-smoke && npm run test:pages-drift && npm run build:site && npm run test:e2e",
     "verify:catalog": "npm run validate:catalog && npm run validate:learning-graph && npm run check:generated && npm run test:fixtures",
     "build:site": "rm -rf .site && jekyll build --source docs --destination .site/it-engineer-knowledge-architecture --baseurl /it-engineer-knowledge-architecture",
     "test:e2e": "playwright test",
-    "test:production-smoke": "node --test tests/smoke-production.test.mjs"
+    "test:production-smoke": "node --test tests/smoke-production.test.mjs",
+    "test:pages-drift": "node --test tests/pages-drift.test.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/scripts/check-pages-drift.mjs
+++ b/scripts/check-pages-drift.mjs
@@ -1,0 +1,276 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { runProductionSmoke } from './smoke-production.mjs';
+
+const DEFAULT_BASE_URL = 'https://itdojp.github.io/it-engineer-knowledge-architecture/';
+const ALERT_MARKER = '<!-- pages-drift-alert -->';
+const ALERT_TITLE = '[Alert][Pages Drift] 公開サイトのデプロイ不整合';
+
+function normalizeApiUrl(value) {
+  return (value || 'https://api.github.com').replace(/\/$/, '');
+}
+
+function parseInteger(value, fallback, minimum = 0) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed >= minimum ? parsed : fallback;
+}
+
+function parseArgs(argv, env = process.env) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith('--')) throw new Error(`Unknown argument: ${key}`);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) throw new Error(`Missing value for ${key}`);
+    values[key.slice(2)] = value;
+    index += 1;
+  }
+  return {
+    repository: values.repository || env.GITHUB_REPOSITORY,
+    token: values.token || env.GITHUB_TOKEN,
+    apiUrl: normalizeApiUrl(values['api-url'] || env.GITHUB_API_URL),
+    baseUrl: values['base-url'] || env.PAGES_BASE_URL || DEFAULT_BASE_URL,
+    expectedShaOverride: values['expected-sha-override'] || env.EXPECTED_SHA_OVERRIDE || '',
+    maxAttempts: parseInteger(values['max-attempts'] || env.DRIFT_MAX_ATTEMPTS, 4, 1),
+    retryDelayMs: parseInteger(values['retry-delay-ms'] || env.DRIFT_RETRY_DELAY_MS, 3_000),
+    timeoutMs: parseInteger(values['timeout-ms'] || env.DRIFT_TIMEOUT_MS, 15_000, 1),
+    reportJson: values['report-json'] || env.DRIFT_REPORT_JSON || 'tmp/pages-drift/report.json',
+    reportMarkdown: values['report-markdown'] || env.DRIFT_REPORT_MARKDOWN || 'tmp/pages-drift/report.md'
+  };
+}
+
+function assertConfig(config) {
+  if (!/^[^/]+\/[^/]+$/.test(config.repository || '')) {
+    throw new Error('repository must be in owner/name format');
+  }
+  if (!config.token) throw new Error('GitHub token is required');
+  if (config.expectedShaOverride && !/^[0-9a-f]{40}$/i.test(config.expectedShaOverride)) {
+    throw new Error('expected SHA override must be a 40-character commit SHA');
+  }
+}
+
+function createApiClient(config, fetchImpl) {
+  const request = async (path, options = {}) => {
+    const response = await fetchImpl(`${config.apiUrl}${path}`, {
+      ...options,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${config.token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+        ...options.headers
+      }
+    });
+    const text = await response.text();
+    let data = null;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        throw new Error(`GitHub API ${options.method || 'GET'} ${path} returned invalid JSON (HTTP ${response.status})`);
+      }
+    }
+    if (!response.ok) {
+      const message = data?.message ? `: ${data.message}` : '';
+      throw new Error(`GitHub API ${options.method || 'GET'} ${path} failed with HTTP ${response.status}${message}`);
+    }
+    return data;
+  };
+  return { request };
+}
+
+async function findLatestSuccessfulPagesDeployment(api, repository) {
+  const deployments = await api.request(`/repos/${repository}/deployments?environment=github-pages&per_page=30`);
+  for (const deployment of deployments) {
+    const statuses = await api.request(`/repos/${repository}/deployments/${deployment.id}/statuses?per_page=30`);
+    if (statuses.some((status) => status.state === 'success')) {
+      return { id: deployment.id, sha: deployment.sha, createdAt: deployment.created_at };
+    }
+  }
+  return null;
+}
+
+async function findOpenAlerts(api, repository) {
+  const alerts = [];
+  for (let page = 1; ; page += 1) {
+    const issues = await api.request(`/repos/${repository}/issues?state=open&per_page=100&page=${page}`);
+    alerts.push(...issues.filter((issue) => !issue.pull_request && (issue.title === ALERT_TITLE || issue.body?.includes(ALERT_MARKER))));
+    if (issues.length < 100) break;
+  }
+  return alerts;
+}
+
+function formatSha(value) {
+  return value ? `\`${value}\`` : '`取得不能`';
+}
+
+function toMarkdown(report) {
+  const lines = [
+    '# Pages drift report',
+    '',
+    ALERT_MARKER,
+    `- Result: **${report.ok ? 'PASS' : 'FAIL'}**`,
+    `- Repository: \`${report.repository}\``,
+    `- Default branch: \`${report.defaultBranch}\``,
+    `- Default branch SHA: ${formatSha(report.defaultBranchSha)}`,
+    `- Expected SHA: ${formatSha(report.expectedSha)}${report.expectedShaOverride ? ' (workflow_dispatch override)' : ''}`,
+    `- Latest successful Pages deployment SHA: ${formatSha(report.deploymentSha)}`,
+    `- Public build-info SHA: ${formatSha(report.publicSha)}`,
+    `- Public URL: ${report.baseUrl}`,
+    `- Checked at: ${report.checkedAt}`,
+    ''
+  ];
+  if (report.reasons.length > 0) {
+    lines.push('## Detected anomalies', '', ...report.reasons.map((reason) => `- ${reason}`), '');
+  }
+  lines.push(
+    '## Production smoke',
+    '',
+    `- Result: **${report.smoke.ok ? 'PASS' : 'FAIL'}**`,
+    `- Attempts: ${report.smoke.attempts}`,
+    `- Failed endpoints: ${report.smoke.endpoints.filter((endpoint) => endpoint.errors.length > 0).map((endpoint) => endpoint.label).join(', ') || 'none'}`,
+    '',
+    'このIssueは定期確認Workflowが管理します。復旧確認時に証跡をコメントして自動クローズします。'
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+async function updateAlert(api, repository, report) {
+  const openAlerts = await findOpenAlerts(api, repository);
+  const body = toMarkdown(report);
+  if (!report.ok) {
+    if (openAlerts.length === 0) {
+      const issue = await api.request(`/repos/${repository}/issues`, {
+        method: 'POST',
+        body: JSON.stringify({ title: ALERT_TITLE, body })
+      });
+      return { action: 'created', issueNumber: issue.number, openAlertCount: 1 };
+    }
+    const primary = openAlerts[0];
+    await api.request(`/repos/${repository}/issues/${primary.number}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ body: `## 不整合の継続を確認\n\n${body}` })
+    });
+    for (const duplicate of openAlerts.slice(1)) {
+      await api.request(`/repos/${repository}/issues/${duplicate.number}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ body: `重複Alertを #${primary.number} に集約するため、このIssueをクローズします。` })
+      });
+      await api.request(`/repos/${repository}/issues/${duplicate.number}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ state: 'closed', state_reason: 'not_planned' })
+      });
+    }
+    return {
+      action: 'commented',
+      issueNumber: primary.number,
+      openAlertCount: 1,
+      closedDuplicateCount: openAlerts.length - 1
+    };
+  }
+  if (openAlerts.length === 0) return { action: 'none', issueNumber: null, openAlertCount: 0 };
+  for (const issue of openAlerts) {
+    await api.request(`/repos/${repository}/issues/${issue.number}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ body: `## 復旧を確認\n\n${body}` })
+    });
+    await api.request(`/repos/${repository}/issues/${issue.number}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'closed', state_reason: 'completed' })
+    });
+  }
+  return { action: 'closed', issueNumber: openAlerts[0].number, openAlertCount: 0, closedCount: openAlerts.length };
+}
+
+async function writeReport(report, config) {
+  for (const [path, content] of [
+    [config.reportJson, `${JSON.stringify(report, null, 2)}\n`],
+    [config.reportMarkdown, toMarkdown(report)]
+  ]) {
+    const target = resolve(path);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, content, 'utf8');
+  }
+}
+
+export async function runPagesDriftCheck(inputConfig, dependencies = {}) {
+  const config = {
+    apiUrl: normalizeApiUrl(inputConfig.apiUrl),
+    repository: inputConfig.repository,
+    token: inputConfig.token,
+    baseUrl: inputConfig.baseUrl || DEFAULT_BASE_URL,
+    expectedShaOverride: inputConfig.expectedShaOverride || '',
+    maxAttempts: inputConfig.maxAttempts ?? 4,
+    retryDelayMs: inputConfig.retryDelayMs ?? 3_000,
+    timeoutMs: inputConfig.timeoutMs ?? 15_000,
+    reportJson: inputConfig.reportJson ?? 'tmp/pages-drift/report.json',
+    reportMarkdown: inputConfig.reportMarkdown ?? 'tmp/pages-drift/report.md'
+  };
+  assertConfig(config);
+  const fetchImpl = dependencies.fetchImpl || globalThis.fetch;
+  const api = dependencies.api || createApiClient(config, fetchImpl);
+  const smokeRunner = dependencies.smokeRunner || runProductionSmoke;
+  const now = dependencies.now || (() => new Date());
+
+  const repository = await api.request(`/repos/${config.repository}`);
+  const defaultBranch = repository.default_branch;
+  const commit = await api.request(`/repos/${config.repository}/commits/${encodeURIComponent(defaultBranch)}`);
+  const deployment = await findLatestSuccessfulPagesDeployment(api, config.repository);
+  const defaultBranchSha = commit.sha;
+  const expectedSha = config.expectedShaOverride || defaultBranchSha;
+  const smoke = await smokeRunner({
+    baseUrl: config.baseUrl,
+    expectedSha,
+    maxAttempts: config.maxAttempts,
+    retryDelayMs: config.retryDelayMs,
+    timeoutMs: config.timeoutMs,
+    reportJson: `${config.reportJson}.smoke.json`,
+    reportMarkdown: `${config.reportMarkdown}.smoke.md`
+  });
+  const reasons = [];
+  if (!deployment) reasons.push('成功済みの github-pages deployment が見つかりません。');
+  if (config.expectedShaOverride && defaultBranchSha !== expectedSha) {
+    reasons.push(`意図的な期待SHAとdefault branch SHAが一致しません: ${expectedSha} != ${defaultBranchSha}`);
+  }
+  if (deployment && deployment.sha !== expectedSha) {
+    reasons.push(`Pages deployment SHAが期待SHAと一致しません: ${deployment.sha} != ${expectedSha}`);
+  }
+  if (smoke.actualSha !== expectedSha) {
+    reasons.push(`公開build-info SHAが期待SHAと一致しません: ${smoke.actualSha || '取得不能'} != ${expectedSha}`);
+  }
+  if (!smoke.ok) reasons.push('本番スモークテストが失敗しました。');
+
+  const report = {
+    ok: reasons.length === 0,
+    repository: config.repository,
+    defaultBranch,
+    defaultBranchSha,
+    expectedSha,
+    expectedShaOverride: config.expectedShaOverride || null,
+    deploymentId: deployment?.id || null,
+    deploymentSha: deployment?.sha || null,
+    publicSha: smoke.actualSha || null,
+    baseUrl: config.baseUrl,
+    checkedAt: now().toISOString(),
+    reasons,
+    smoke,
+    alert: null
+  };
+  report.alert = await updateAlert(api, config.repository, report);
+  await writeReport(report, config);
+  return report;
+}
+
+export { ALERT_MARKER, ALERT_TITLE, parseArgs, toMarkdown };
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    const report = await runPagesDriftCheck(parseArgs(process.argv.slice(2)));
+    console.log(toMarkdown(report));
+    if (!report.ok) process.exitCode = 1;
+  } catch (error) {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/tests/pages-drift.test.mjs
+++ b/tests/pages-drift.test.mjs
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+import { ALERT_MARKER, ALERT_TITLE, runPagesDriftCheck } from '../scripts/check-pages-drift.mjs';
+
+const REPOSITORY = 'itdojp/it-engineer-knowledge-architecture';
+const SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+
+class FakeApi {
+  constructor({ deploymentSha = SHA, publicIssues = [] } = {}) {
+    this.deploymentSha = deploymentSha;
+    this.issues = structuredClone(publicIssues);
+    this.calls = [];
+    this.nextIssue = 900;
+  }
+
+  async request(path, options = {}) {
+    const method = options.method || 'GET';
+    const body = options.body ? JSON.parse(options.body) : null;
+    this.calls.push({ path, method, body });
+    if (method === 'GET' && path === `/repos/${REPOSITORY}`) return { default_branch: 'main' };
+    if (method === 'GET' && path === `/repos/${REPOSITORY}/commits/main`) return { sha: SHA };
+    if (method === 'GET' && path.includes('/deployments?')) {
+      return [{ id: 77, sha: this.deploymentSha, created_at: '2026-07-11T00:00:00Z' }];
+    }
+    if (method === 'GET' && path.includes('/deployments/77/statuses')) return [{ state: 'success' }];
+    if (method === 'GET' && path.includes('/issues?state=open')) return this.issues.filter((issue) => issue.state !== 'closed');
+    if (method === 'POST' && path === `/repos/${REPOSITORY}/issues`) {
+      const issue = { number: this.nextIssue++, state: 'open', title: body.title, body: body.body };
+      this.issues.push(issue);
+      return issue;
+    }
+    const commentMatch = path.match(/\/issues\/(\d+)\/comments$/);
+    if (method === 'POST' && commentMatch) return { id: 1, body: body.body };
+    const issueMatch = path.match(/\/issues\/(\d+)$/);
+    if (method === 'PATCH' && issueMatch) {
+      const issue = this.issues.find((candidate) => candidate.number === Number(issueMatch[1]));
+      Object.assign(issue, body);
+      return issue;
+    }
+    throw new Error(`Unhandled fake API request: ${method} ${path}`);
+  }
+}
+
+function smokeResult({ ok = true, actualSha = SHA } = {}) {
+  return {
+    ok,
+    actualSha,
+    attempts: 1,
+    endpoints: ok ? [] : [{ label: '/build-info.json', errors: ['SHA mismatch'] }]
+  };
+}
+
+async function runWith(api, smoke, override = '') {
+  const scratchRoot = join(process.cwd(), '.test-tmp');
+  await mkdir(scratchRoot, { recursive: true });
+  const directory = await mkdtemp(join(scratchRoot, 'pages-drift-'));
+  const config = {
+    repository: REPOSITORY,
+    token: 'test-token',
+    apiUrl: 'https://api.example.test',
+    baseUrl: 'https://example.test/site/',
+    expectedShaOverride: override,
+    maxAttempts: 1,
+    retryDelayMs: 0,
+    timeoutMs: 100,
+    reportJson: join(directory, 'report.json'),
+    reportMarkdown: join(directory, 'report.md')
+  };
+  try {
+    const report = await runPagesDriftCheck(config, {
+      api,
+      smokeRunner: async () => smoke,
+      now: () => new Date('2026-07-11T01:02:03Z')
+    });
+    return {
+      report,
+      reportJson: JSON.parse(await readFile(config.reportJson, 'utf8')),
+      reportMarkdown: await readFile(config.reportMarkdown, 'utf8')
+    };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test.after(async () => {
+  await rm(join(process.cwd(), '.test-tmp'), { recursive: true, force: true });
+});
+
+test('all three revisions match without mutating Issues', async () => {
+  const api = new FakeApi();
+  const { report, reportJson, reportMarkdown } = await runWith(api, smokeResult());
+  assert.equal(report.ok, true);
+  assert.equal(report.alert.action, 'none');
+  assert.equal(reportJson.defaultBranchSha, SHA);
+  assert.match(reportMarkdown, /Result: \*\*PASS\*\*/);
+  assert.equal(api.calls.some((call) => call.method !== 'GET'), false);
+});
+
+test('mismatch creates one marked alert Issue', async () => {
+  const api = new FakeApi({ deploymentSha: OTHER_SHA });
+  const { report } = await runWith(api, smokeResult({ ok: false, actualSha: OTHER_SHA }));
+  assert.equal(report.ok, false);
+  assert.equal(report.alert.action, 'created');
+  assert.equal(api.issues.length, 1);
+  assert.equal(api.issues[0].title, ALERT_TITLE);
+  assert.match(api.issues[0].body, new RegExp(ALERT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});
+
+test('repeated mismatch comments on the existing alert without duplication', async () => {
+  const api = new FakeApi({
+    deploymentSha: OTHER_SHA,
+    publicIssues: [{ number: 42, state: 'open', title: ALERT_TITLE, body: ALERT_MARKER }]
+  });
+  const { report } = await runWith(api, smokeResult({ ok: false, actualSha: OTHER_SHA }));
+  assert.equal(report.alert.action, 'commented');
+  assert.equal(report.alert.issueNumber, 42);
+  assert.equal(api.issues.length, 1);
+  assert.equal(api.calls.filter((call) => call.path.endsWith('/comments')).length, 1);
+  assert.equal(api.calls.some((call) => call.method === 'POST' && call.path === `/repos/${REPOSITORY}/issues`), false);
+});
+
+test('mismatch consolidates pre-existing duplicate alerts into one open Issue', async () => {
+  const api = new FakeApi({
+    deploymentSha: OTHER_SHA,
+    publicIssues: [
+      { number: 42, state: 'open', title: ALERT_TITLE, body: ALERT_MARKER },
+      { number: 43, state: 'open', title: 'legacy duplicate', body: ALERT_MARKER }
+    ]
+  });
+  const { report } = await runWith(api, smokeResult({ ok: false, actualSha: OTHER_SHA }));
+  assert.equal(report.alert.issueNumber, 42);
+  assert.equal(report.alert.closedDuplicateCount, 1);
+  assert.deepEqual(api.issues.map((issue) => issue.state), ['open', 'closed']);
+});
+
+test('recovery comments on and closes every open drift alert', async () => {
+  const api = new FakeApi({
+    publicIssues: [
+      { number: 42, state: 'open', title: ALERT_TITLE, body: ALERT_MARKER },
+      { number: 43, state: 'open', title: 'legacy duplicate', body: ALERT_MARKER }
+    ]
+  });
+  const { report } = await runWith(api, smokeResult());
+  assert.equal(report.ok, true);
+  assert.equal(report.alert.action, 'closed');
+  assert.equal(report.alert.closedCount, 2);
+  assert.deepEqual(api.issues.map((issue) => issue.state), ['closed', 'closed']);
+  assert.equal(api.calls.filter((call) => call.path.endsWith('/comments')).length, 2);
+});
+
+test('workflow_dispatch override provides an intentional mismatch test', async () => {
+  const api = new FakeApi();
+  const { report } = await runWith(api, smokeResult({ ok: false, actualSha: SHA }), OTHER_SHA);
+  assert.equal(report.ok, false);
+  assert.equal(report.expectedSha, OTHER_SHA);
+  assert.ok(report.reasons.some((reason) => reason.includes('意図的な期待SHA')));
+  assert.equal(report.alert.action, 'created');
+});
+
+test('invalid override is rejected before any GitHub API request', async () => {
+  const api = new FakeApi();
+  await assert.rejects(
+    runPagesDriftCheck({
+      repository: REPOSITORY,
+      token: 'test-token',
+      expectedShaOverride: 'invalid'
+    }, { api, smokeRunner: async () => smokeResult() }),
+    /40-character commit SHA/
+  );
+  assert.equal(api.calls.length, 0);
+});


### PR DESCRIPTION
## 概要

Issue #181 の残作業として、GitHub Pagesのdefault branch・最新成功deployment・公開build情報を日次比較し、公開URLも本番スモークするdrift監視を追加します。

## 変更

- `pages-drift-check.yml` を日次・手動実行に対応
- default branch SHA、最新成功 `github-pages` deployment SHA、公開 `build-info.json.sha` を比較
- `/`, `/books/`, `/paths/`, `/en/`, `/404.html`, `/build-info.json` の既存production smokeを再利用
- 異常時だけmarker付きAlert Issueを作成し、継続時は同じIssueへ追記
- 既存重複Alertは1件へ集約し、復旧時は証跡コメント後にclose
- job summaryとartifactへJSON/Markdownレポートを保存
- `workflow_dispatch` の期待SHA overrideで意図的な不一致試験を可能化
- READMEとPagesデプロイRunbookにActions artifact固定、初期設定、確認・復旧手順、bot commit禁止を明記

## 検証

- `npm ci`（0 vulnerabilities）
- `npm run verify`
  - catalog 49件・learning path 7件
  - production smoke 7件
  - Pages drift 7件
  - Playwright/axe 30件
- Ruby YAML parse: success
- actionlint v1.7.12（新規Workflow）: success
- `git diff --check`: success
- 実GitHub API・公開サイトを使ったローカル統合確認: main / deployment / public SHA `e8bd6b70b4fe3233da6738c81074505f0e8181e8` で一致、Issue mutationなし

## マージ後確認

1. Deploy Pagesのpost-deploy smoke成功
2. 入力なしのPages drift check成功
3. SHA overrideによる不一致を2回実行し、Alertが1件だけ作成・更新されること
4. 入力なしで再実行し、復旧コメントと自動closeを確認
5. 公開build-info SHAとmerge commit SHAの一致を確認

Refs #181
