### PR TITLE
fix: address Pages drift review feedback

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,11 +3,6 @@ name: Deploy Pages
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'docs/**'
-      - 'scripts/write-build-info.mjs'
-      - 'scripts/smoke-production.mjs'
-      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/pages-drift-check.yml
+++ b/.github/workflows/pages-drift-check.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Check Pages drift and manage alert
         id: drift
         continue-on-error: true

--- a/docs/publishing/pages-deployment-runbook.md
+++ b/docs/publishing/pages-deployment-runbook.md
@@ -33,7 +33,7 @@ gh workflow run deploy-pages.yml --repo itdojp/it-engineer-knowledge-architectur
 
 ## 通常のデプロイと検証
 
-`main` の `docs/**`、デプロイWorkflow、build情報生成、または本番スモークの変更でDeploy Pagesが起動する。処理は次の3 jobで構成する。
+`main` の更新は変更パスを問わずDeploy Pagesを起動する。定期drift確認がdefault branchの最新SHAを期待値とするため、公開内容に影響しない変更も同じSHAのartifactとして再デプロイし、default branchと公開SHAの一貫性を維持する。処理は次の3 jobで構成する。
 
 1. Jekyllをbuildし、`_site/build-info.json` を追加してPages artifactを作る。
 2. artifactを `github-pages` environmentへデプロイする。

--- a/scripts/check-pages-drift.mjs
+++ b/scripts/check-pages-drift.mjs
@@ -147,12 +147,12 @@ async function updateAlert(api, repository, report) {
       });
       return { action: 'created', issueNumber: issue.number, openAlertCount: 1 };
     }
-    const primary = openAlerts[0];
+    const primary = openAlerts.find((issue) => issue.title === ALERT_TITLE) || openAlerts[0];
     await api.request(`/repos/${repository}/issues/${primary.number}/comments`, {
       method: 'POST',
       body: JSON.stringify({ body: `## 不整合の継続を確認\n\n${body}` })
     });
-    for (const duplicate of openAlerts.slice(1)) {
+    for (const duplicate of openAlerts.filter((issue) => issue.number !== primary.number)) {
       await api.request(`/repos/${repository}/issues/${duplicate.number}/comments`, {
         method: 'POST',
         body: JSON.stringify({ body: `重複Alertを #${primary.number} に集約するため、このIssueをクローズします。` })

--- a/tests/pages-drift.test.mjs
+++ b/tests/pages-drift.test.mjs
@@ -126,14 +126,14 @@ test('mismatch consolidates pre-existing duplicate alerts into one open Issue', 
   const api = new FakeApi({
     deploymentSha: OTHER_SHA,
     publicIssues: [
-      { number: 42, state: 'open', title: ALERT_TITLE, body: ALERT_MARKER },
-      { number: 43, state: 'open', title: 'legacy duplicate', body: ALERT_MARKER }
+      { number: 42, state: 'open', title: 'legacy duplicate', body: ALERT_MARKER },
+      { number: 43, state: 'open', title: ALERT_TITLE, body: ALERT_MARKER }
     ]
   });
   const { report } = await runWith(api, smokeResult({ ok: false, actualSha: OTHER_SHA }));
-  assert.equal(report.alert.issueNumber, 42);
+  assert.equal(report.alert.issueNumber, 43);
   assert.equal(report.alert.closedDuplicateCount, 1);
-  assert.deepEqual(api.issues.map((issue) => issue.state), ['open', 'closed']);
+  assert.deepEqual(api.issues.map((issue) => issue.state), ['closed', 'open']);
 });
 
 test('recovery comments on and closes every open drift alert', async () => {


### PR DESCRIPTION
## 概要

PR #183 のマージ後に到着したCodex/Copilotレビュー3件をすべて反映します。

## 対応

1. default branchの非公開対象commitで誤検知しないよう、Deploy Pagesを`main`の全pushで実行し、公開SHAを常にdefault branch SHAへ追従させる
2. Alertが複数ある場合は正規タイトルのIssueを優先してprimaryに選び、それ以外を重複としてcloseする
3. Pages drift workflowに`actions/setup-node@v6`とNode.js 24を明示する
4. Runbookと重複Issueテストを更新する

## 検証

- `npm ci`: 0 vulnerabilities
- `npm run test:pages-drift`: 7 passed
- `npm run verify`: production smoke 7、Pages drift 7、Playwright/axe 30 passed
- Ruby YAML parse: success
- actionlint v1.7.12（対象2 Workflow）: success
- `git diff --check`: success

Follow-up to #183
Refs #181
