### PR TITLE
catalog: record beginner-track quality sprint 186

### DIFF
--- a/books/youtube/books.yaml
+++ b/books/youtube/books.yaml
@@ -10,10 +10,10 @@
   hook_ja: 本動画は、実務で必要とされる知識を体系的に深めたいエンジニアの方々に向けた解説です。
   hook_en: Are you struggling with ...?
 - id: wsl2-linux-essentials-book
-  title_ja: やさしく学ぶLinux WSL2ではじめる基礎
+  title_ja: WSL2 Linux実践ガイド
   title_en: ''
   category: 未経験者向け
-  level: IT未経験者・初学者
+  level: Linux基礎を学習済みの初学者
   url: https://itdojp.github.io/wsl2-linux-essentials-book/
   repo: https://github.com/itdojp/wsl2-linux-essentials-book
   youtube_id_ja: ''

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "updatedAt": "2026-07-10",
+  "updatedAt": "2026-07-11",
   "sourcePolicy": {
     "canonical": "docs/_data/catalog.json",
     "derivedFiles": [
@@ -61,8 +61,8 @@
         "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
       ],
       "summary": {
-        "ja": "",
-        "en": "A visual introduction to Linux basics, core commands, filesystems, networking, and containers."
+        "ja": "図解を中心に、コンピュータとOSの仕組み、Linuxの基本コマンド、権限・ユーザー管理、テキスト処理、パッケージ管理、トラブル対応、簡単なシェルスクリプトを初学者向けに学べる入門書です。",
+        "en": "A visual introduction to computer and operating-system concepts, core Linux commands, permissions and users, text and package management, troubleshooting, and simple shell scripts."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
@@ -72,8 +72,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-11",
+      "reviewIssue": 186,
       "ux": {
         "profile": "A",
         "modules": {
@@ -88,24 +88,22 @@
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
-      "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
-      ],
+      "updatedAt": "2026-07-11",
+      "notes": [],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/illustrated-linux-basics-book/blob/main/README.md",
+        "https://github.com/itdojp/illustrated-linux-basics-book/blob/main/book-config.json",
+        "https://github.com/itdojp/illustrated-linux-basics-book/blob/main/docs/index.md",
+        "https://github.com/itdojp/illustrated-linux-basics-book/pull/95",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/186"
       ]
     },
     {
       "id": "wsl2-linux-essentials-book",
       "displayOrder": 2,
       "title": {
-        "ja": "やさしく学ぶLinux WSL2ではじめる基礎",
-        "en": "やさしく学ぶLinux WSL2ではじめる基礎"
+        "ja": "WSL2 Linux実践ガイド",
+        "en": "WSL2 Linux実践ガイド"
       },
       "officialEnglishTitle": null,
       "status": "published",
@@ -130,8 +128,8 @@
         "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
       ],
       "summary": {
-        "ja": "",
-        "en": "Uses WSL2 on Windows as a safe learning environment for Linux setup, shell usage, processes, networking, and scripting."
+        "ja": "Linux基礎を終えた読者が、Windows上のWSL2とUbuntuを使って、ファイル・権限、テキスト処理、プロセス／サービス、ネットワーク、シェルスクリプトを実践し、学習用WordPress環境の構築まで進める教材です。",
+        "en": "A hands-on guide for readers with Linux basics to set up WSL2 and Ubuntu on Windows, practice files and permissions, text processing, processes and services, networking, shell scripting, and build a local WordPress environment."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
@@ -141,8 +139,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-11",
+      "reviewIssue": 186,
       "ux": {
         "profile": "A",
         "modules": {
@@ -157,16 +155,14 @@
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
-      "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
-      ],
+      "updatedAt": "2026-07-11",
+      "notes": [],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/wsl2-linux-essentials-book/blob/main/README.md",
+        "https://github.com/itdojp/wsl2-linux-essentials-book/blob/main/book-config.json",
+        "https://github.com/itdojp/wsl2-linux-essentials-book/blob/main/docs/index.md",
+        "https://github.com/itdojp/wsl2-linux-essentials-book/pull/130",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/186"
       ]
     },
     {

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -89,7 +89,9 @@
       },
       "addedAt": null,
       "updatedAt": "2026-07-11",
-      "notes": [],
+      "notes": [
+        "2026-07-11の品質スプリント#186でUX構成（Profile Aとmodules）を実ファイルに基づき確認済み。"
+      ],
       "sourceRefs": [
         "https://github.com/itdojp/illustrated-linux-basics-book/blob/main/README.md",
         "https://github.com/itdojp/illustrated-linux-basics-book/blob/main/book-config.json",
@@ -156,7 +158,9 @@
       },
       "addedAt": null,
       "updatedAt": "2026-07-11",
-      "notes": [],
+      "notes": [
+        "2026-07-11の品質スプリント#186でUX構成（Profile Aとmodules）を実ファイルに基づき確認済み。"
+      ],
       "sourceRefs": [
         "https://github.com/itdojp/wsl2-linux-essentials-book/blob/main/README.md",
         "https://github.com/itdojp/wsl2-linux-essentials-book/blob/main/book-config.json",

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -127,13 +127,15 @@
         "beginner"
       ],
       "audiences": [
-        "IT未経験者・初学者 / プログラミングやLinuxの基礎を楽しく学ぶ"
+        "Linuxの基本操作を学習済みの初学者 / Windows上のWSL2で実践的なLinuxスキルを学ぶ"
       ],
       "summary": {
         "ja": "Linux基礎を終えた読者が、Windows上のWSL2とUbuntuを使って、ファイル・権限、テキスト処理、プロセス／サービス、ネットワーク、シェルスクリプトを実践し、学習用WordPress環境の構築まで進める教材です。",
         "en": "A hands-on guide for readers with Linux basics to set up WSL2 and Ubuntu on Windows, practice files and permissions, text processing, processes and services, networking, shell scripting, and build a local WordPress environment."
       },
-      "prerequisites": [],
+      "prerequisites": [
+        "illustrated-linux-basics-book"
+      ],
       "estimatedWeeks": null,
       "recommendedAfter": [],
       "languages": [

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -63,8 +63,8 @@ Audience: absolute beginners and first-time learners who want a gentle introduct
 
 | Canonical title | Availability | Audience | Short English summary | Links |
 | --- | --- | --- | --- | --- |
-| 図解でわかるLinux基礎 | `JA only` | Absolute beginners | A visual introduction to Linux basics, core commands, filesystems, networking, and containers. | [Read](https://itdojp.github.io/illustrated-linux-basics-book/) / [Repository](https://github.com/itdojp/illustrated-linux-basics-book) |
-| やさしく学ぶLinux WSL2ではじめる基礎 | `JA only` | Absolute beginners | Uses WSL2 on Windows as a safe learning environment for Linux setup, shell usage, processes, networking, and scripting. | [Read](https://itdojp.github.io/wsl2-linux-essentials-book/) / [Repository](https://github.com/itdojp/wsl2-linux-essentials-book) |
+| 図解でわかるLinux基礎 | `JA only` | Absolute beginners | A visual introduction to computer and operating-system concepts, core Linux commands, permissions and users, text and package management, troubleshooting, and simple shell scripts. | [Read](https://itdojp.github.io/illustrated-linux-basics-book/) / [Repository](https://github.com/itdojp/illustrated-linux-basics-book) |
+| WSL2 Linux実践ガイド | `JA only` | Readers with Linux basics | A hands-on guide for readers with Linux basics to set up WSL2 and Ubuntu on Windows, practice files and permissions, text processing, processes and services, networking, shell scripting, and build a local WordPress environment. | [Read](https://itdojp.github.io/wsl2-linux-essentials-book/) / [Repository](https://github.com/itdojp/wsl2-linux-essentials-book) |
 
 ### Professional Foundations
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -59,7 +59,7 @@ Recommended reading flow after the review:
 
 ### Beginner Track
 
-Audience: absolute beginners and first-time learners who want a gentle introduction to Linux and everyday development tools.
+Audience: first-time learners starting with a gentle Linux introduction, followed by beginners who want to apply those basics in WSL2.
 
 | Canonical title | Availability | Audience | Short English summary | Links |
 | --- | --- | --- | --- | --- |

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "updatedAt": "2026-07-10",
+  "updatedAt": "2026-07-11",
   "generatedFrom": "docs/_data/catalog.json",
   "modulesCatalog": [
     "quickStart",
@@ -303,7 +303,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "catalog generated"
     },
     "incident-response-basics-book": {
       "repo": "itdojp/incident-response-basics-book",
@@ -671,7 +671,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "catalog generated"
     }
   }
 }

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -303,7 +303,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "catalog generated"
+      "notes": "2026-07-11の品質スプリント#186でUX構成（Profile Aとmodules）を実ファイルに基づき確認済み。"
     },
     "incident-response-basics-book": {
       "repo": "itdojp/incident-response-basics-book",
@@ -671,7 +671,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "catalog generated"
+      "notes": "2026-07-11の品質スプリント#186でUX構成（Profile Aとmodules）を実ファイルに基づき確認済み。"
     }
   }
 }


### PR DESCRIPTION
## Summary

Refs itdojp/it-engineer-knowledge-architecture#186

Quality Sprint #186で監査を完了した次の2冊について、正本カタログの読者向けメタデータとレビュー証跡を更新します。

- `itdojp/illustrated-linux-basics-book`
- `itdojp/wsl2-linux-essentials-book`

書籍側の修正証跡:

- https://github.com/itdojp/illustrated-linux-basics-book/pull/95
- https://github.com/itdojp/wsl2-linux-essentials-book/pull/130

## Changes

- `summary.ja` をREADME・本文の到達範囲に基づく1文へ補完
- `summary.en` を日本語概要および実際の章構成と整合
- WSL2書籍の表示名をリポジトリ正本の `WSL2 Linux実践ガイド` に統一
- WSL2書籍の対象読者と前提書籍をREADMEの「次のステップ」という位置付けに整合
- `lastReviewedAt` を `2026-07-11`、`reviewIssue` を `186` に設定
- Profile A / modulesを両リポジトリの `book-config.json` と実ファイルで確認し、暫定メモを削除
- `sourceRefs` を現行README、設定、本文、書籍PR、Issueへ更新
- 正本から `docs/publishing/book-registry.json` を再生成
- 英語カタログとYouTube運用メタデータの対象2行を正本と同期

## Decisions

- `estimatedWeeks` は `null` を維持します。両リポジトリのREADME、`book-config.json`、本文に正式な学習期間の根拠がなく、旧資料の値を推測で転記しないためです。
- WSL2書籍の `prerequisites` は、READMEが `illustrated-linux-basics-book` の次のステップと明記しているため、同書を設定します。
- UXは両書籍の `book-config.json` が同じProfile A / modulesを明示し、Quick Start、読み方、概念図、用語導線の実体も確認できたため、値を維持して暫定メモだけを解消します。

## Verification

- `npm ci` — pass、0 vulnerabilities
- `npm run generate` — pass
- `npm run verify` — pass（catalog 49 records、learning graph、fixtures、smoke単体テスト7件、drift単体テスト7件、Jekyll build、Playwright 30件）
- `node scripts/validate-ux-registry.js` — pass（41 books）
- `npm audit --audit-level=moderate` — pass、0 vulnerabilities
- `git diff --check` — pass
- `books/youtube/books.yaml` のYAML parseとWSL2書籍名照合 — pass
- Quality Sprint選定ロジックの再現確認 — 対象2冊は `lastReviewedAt: 2026-07-11` となり、未レビュー書籍より後順位で再選定されない

## After merge

- mainのDeploy Pagesとpost-deploy production smokeを確認
- `/build-info.json` のSHAとmain SHAを照合
- Pages drift正常系を実行・確認
- 公開 `/books/` で2冊の日本語概要とWSL2書籍名を確認

## Follow-up

#187では、他書籍を含むカタログの概要・前提知識・学習期間等を段階的に整備します。本PRは#186対象2レコードだけに限定しています。