### PR TITLE
ci: skip YouTube update without credentials

### DIFF
--- a/.github/workflows/youtube_sync.yml
+++ b/.github/workflows/youtube_sync.yml
@@ -31,8 +31,23 @@ jobs:
       - name: 1. Generate description texts
         run: python scripts/generate_descriptions.py
 
-      - name: 2. Update YouTube Videos via API
+      - name: Check whether YouTube credentials are available
+        id: youtube_credentials
         env:
-          # GitHub Secrets から YouTube の認証情報を読み込む
+          YOUTUBE_TOKEN_JSON: ${{ secrets.YOUTUBE_TOKEN_JSON }}
+        run: |
+          if [[ -n "$YOUTUBE_TOKEN_JSON" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 2. Update YouTube Videos via API
+        if: ${{ steps.youtube_credentials.outputs.available == 'true' }}
+        env:
           YOUTUBE_TOKEN_JSON: ${{ secrets.YOUTUBE_TOKEN_JSON }}
         run: python scripts/update_youtube_videos.py
+
+      - name: Skip YouTube API update when credentials are unavailable
+        if: ${{ steps.youtube_credentials.outputs.available != 'true' }}
+        run: echo "::notice::YOUTUBE_TOKEN_JSON is not configured; generated descriptions were validated without updating YouTube."


### PR DESCRIPTION
## Summary

Refs #186 and follows #190.

The merge of #190 correctly synchronized the WSL2 title in `books/youtube/books.yaml`, which triggered the `Sync YouTube Descriptions` workflow. Run [29148891843](https://github.com/itdojp/it-engineer-knowledge-architecture/actions/runs/29148891843) then failed because `YOUTUBE_TOKEN_JSON` is not configured and the workflow passed an empty value to `json.loads`.

## Change

- Detect whether `YOUTUBE_TOKEN_JSON` is available without printing its value.
- Run the YouTube API update only when credentials are configured.
- Emit an Actions notice and complete successfully when credentials are unavailable, while retaining description generation as validation.
- Keep the secret scoped only to the credential probe and API update steps rather than exposing it at job scope.

## Verification

- Ruby YAML parse — pass
- Credential probe with an empty value — `available=false`
- Credential probe with a non-empty redacted fixture — `available=true`
- `git diff --check` — pass

## Production verification

After merge, confirm the main `Sync YouTube Descriptions` run succeeds through the no-credentials path. No YouTube API mutation is expected while the secret remains unavailable.
