### PR TITLE
catalog: audit three professional foundations books

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -199,15 +199,19 @@
         "all-engineers"
       ],
       "audiences": [
-        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+        "一次情報を起点に調査・検証・レビューを進めたいITエンジニア",
+        "テックリード、EM、レビュー担当として根拠の明示を標準化したい人",
+        "AIを補助的に使いつつ、再現性と安全性を崩したくない実務者"
       ],
       "summary": {
-        "ja": "",
+        "ja": "一次情報を起点に、検索、仕様読解、検証、引用、AI利用ガードレールを身につけ、調査結果を再現性と安全性を備えた根拠として説明できるようにする実務書です。",
         "en": "Explains how to search, verify, quote, and document evidence so engineering decisions stay defensible."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "issue-driven-work-book"
+      ],
       "languages": [
         "ja"
       ],
@@ -219,7 +223,7 @@
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
@@ -229,16 +233,20 @@
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査#193で、book-configのProfile Bとmodulesを、公開トップ、第4章の検証手順、ケーススタディ、チェックリスト、図表索引の実体と照合済み。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/evidence-based-engineering-book/blob/main/README.md",
+        "https://github.com/itdojp/evidence-based-engineering-book/blob/main/docs/index.md",
+        "https://github.com/itdojp/evidence-based-engineering-book/blob/main/book-config.json",
+        "https://github.com/itdojp/evidence-based-engineering-book/blob/main/docs/_data/navigation.yml",
+        "https://github.com/itdojp/evidence-based-engineering-book/blob/main/docs/appendices/checklists/index.md",
+        "https://github.com/itdojp/evidence-based-engineering-book/blob/main/docs/appendices/figure-index/index.md",
+        "https://github.com/itdojp/evidence-based-engineering-book/blob/main/docs/appendices/case-studies/index.md",
+        "docs/professional-foundations.md",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193"
       ]
     },
     {
@@ -268,15 +276,19 @@
         "all-engineers"
       ],
       "audiences": [
-        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+        "Issue / PRを使っているが、起票・レビュー・完了の品質が安定しない人",
+        "口頭・チャット依存の進め方から脱却し、引き継ぎ可能な形に整えたい人",
+        "複数人での合意形成を、テンプレートとチェックリストで再現可能にしたい人"
       ],
       "summary": {
-        "ja": "",
+        "ja": "IssueとPRの作成、DoR/DoD、進捗報告、合意形成、ナレッジ化を、テンプレートとチェックリストでレビュー可能かつ再現可能にする実務書です。",
         "en": "Shows how to manage work with high-quality issues and pull requests for tracking, reporting, and consensus building."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "engineering-documentation-book"
+      ],
       "languages": [
         "ja"
       ],
@@ -285,29 +297,34 @@
       "lastReviewedAt": null,
       "reviewIssue": null,
       "ux": {
-        "profile": "B",
+        "profile": "A",
         "modules": {
-          "quickStart": false,
-          "readingGuide": false,
+          "quickStart": true,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
-          "legalNotice": false,
+          "figureIndex": false,
+          "legalNotice": true,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/issue-driven-work-book/blob/main/README.md",
+        "https://github.com/itdojp/issue-driven-work-book/blob/main/docs/index.md",
+        "https://github.com/itdojp/issue-driven-work-book/blob/main/book-config.json",
+        "https://github.com/itdojp/issue-driven-work-book/blob/main/docs/_data/navigation.yml",
+        "https://github.com/itdojp/issue-driven-work-book/blob/main/docs/appendices/templates/triage-matrix/index.md",
+        "https://github.com/itdojp/issue-driven-work-book/blob/main/docs/appendices/checklists/index.md",
+        "https://github.com/itdojp/issue-driven-work-book/blob/main/docs/appendices/case-studies/index.md",
+        "https://github.com/itdojp/issue-driven-work-book/blob/main/LICENSE.md",
+        "docs/professional-foundations.md",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193"
       ]
     },
     {
@@ -337,15 +354,19 @@
         "all-engineers"
       ],
       "audiences": [
-        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+        "README / 手順書 / Runbook / ADR / ポストモーテムを体系的に整えたい初級〜中級エンジニア",
+        "レビュー観点を揃えたいテックリード / EM",
+        "Docs-as-Codeを導入したい開発チーム"
       ],
       "summary": {
-        "ja": "",
+        "ja": "初級〜中級エンジニアが、README、手順書、Runbook、ADR、障害報告、ポストモーテムを設計し、レビュー、版管理、再利用テンプレートを含むDocs-as-Code運用へ組み込むための実務書です。",
         "en": "Covers practical engineering documents such as READMEs, procedures, runbooks, ADRs, and postmortems."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "security-privacy-literacy-book"
+      ],
       "languages": [
         "ja"
       ],
@@ -357,26 +378,30 @@
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
+          "figureIndex": false,
           "legalNotice": false,
-          "glossary": false
+          "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引は未実装。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/engineering-documentation-book/blob/main/README.md",
+        "https://github.com/itdojp/engineering-documentation-book/blob/main/docs/index.md",
+        "https://github.com/itdojp/engineering-documentation-book/blob/main/book-config.json",
+        "https://github.com/itdojp/engineering-documentation-book/blob/main/docs/_data/navigation.yml",
+        "https://github.com/itdojp/engineering-documentation-book/blob/main/docs/appendices/templates/runbook/index.md",
+        "https://github.com/itdojp/engineering-documentation-book/blob/main/docs/appendices/checklists/index.md",
+        "https://github.com/itdojp/engineering-documentation-book/blob/main/docs/appendices/glossary/index.md",
+        "docs/professional-foundations.md",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193"
       ]
     },
     {

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -183,15 +183,15 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
+        "figureIndex": false,
         "legalNotice": false,
-        "glossary": false
+        "glossary": true
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引は未実装。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
     },
     "ethereum-learning-bootcamp": {
       "repo": "itdojp/ethereum-learning-bootcamp",
@@ -215,7 +215,7 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
@@ -223,7 +223,7 @@
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査#193で、book-configのProfile Bとmodulesを、公開トップ、第4章の検証手順、ケーススタディ、チェックリスト、図表索引の実体と照合済み。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
     },
     "formal-methods-book": {
       "repo": "itdojp/formal-methods-book",
@@ -324,18 +324,18 @@
     "issue-driven-work-book": {
       "repo": "itdojp/issue-driven-work-book",
       "pages": "https://itdojp.github.io/issue-driven-work-book/",
-      "profile": "B",
+      "profile": "A",
       "modules": {
-        "quickStart": false,
-        "readingGuide": false,
+        "quickStart": true,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
+        "figureIndex": false,
+        "legalNotice": true,
         "glossary": false
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
     },
     "IT-engineer-communication-book": {
       "repo": "itdojp/IT-engineer-communication-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -10,7 +10,7 @@
   },
   "debt": {
     "emptySummaryJa": {
-      "count": 37,
+      "count": 34,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -26,14 +26,11 @@
         "cloud-infra-book",
         "computational-physicalism-book",
         "cs-visionaries-book",
-        "engineering-documentation-book",
         "ethereum-learning-bootcamp",
-        "evidence-based-engineering-book",
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
         "incident-response-basics-book",
-        "issue-driven-work-book",
         "it-infra-security-guide-book",
         "it-infra-software-essentials-book",
         "kubernetes-basics-book",
@@ -214,7 +211,7 @@
       ]
     },
     "provisionalNotes": {
-      "count": 37,
+      "count": 34,
       "books": [
         {
           "id": "BioinformaticsGuide-book",
@@ -328,23 +325,7 @@
           ]
         },
         {
-          "id": "engineering-documentation-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
           "id": "ethereum-learning-bootcamp",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
-          "id": "evidence-based-engineering-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
             "日本語個別概要はREADME公開カタログ上で未記載。",
@@ -377,14 +358,6 @@
         },
         {
           "id": "incident-response-basics-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
-          "id": "issue-driven-work-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
             "日本語個別概要はREADME公開カタログ上で未記載。",
@@ -558,7 +531,7 @@
       ]
     },
     "uxEvidenceCandidates": {
-      "count": 34,
+      "count": 31,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -575,14 +548,11 @@
         "composable-software-design-book",
         "computational-physicalism-book",
         "cs-visionaries-book",
-        "engineering-documentation-book",
         "ethereum-learning-bootcamp",
-        "evidence-based-engineering-book",
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
         "incident-response-basics-book",
-        "issue-driven-work-book",
         "it-infra-security-guide-book",
         "it-infra-software-essentials-book",
         "negotiation-for-engineers-book",
@@ -662,7 +632,7 @@
         {
           "identifier": "cloud-infra-handbook",
           "path": "docs/_data/catalog.json",
-          "line": 3092,
+          "line": 3117,
           "column": 22
         }
       ]


### PR DESCRIPTION
## Summary

Closes the metadata-content slice of #193  
Refs #187

`professional-foundations`の導入順先頭3冊について、書籍側`main`のREADME、公開本文、設定、navigation、付録を根拠に、読者向け概要、対象読者、推奨順、UX判定、監査notes、sourceRefsを更新します。

`publishedAt` / `addedAt`が未記録のため、実公開日時の「古い順」は分かりません。対象は`displayOrder`とPhase 0導入順に基づいて選定しました。

## Books

- `evidence-based-engineering-book`
- `issue-driven-work-book`
- `engineering-documentation-book`

## Changes

- Add 60–180-character Japanese summaries grounded in current published content.
- Replace the generic audience text with each book's documented readers.
- Add the documented Professional Foundations reading sequence through `recommendedAfter`.
- Keep `estimatedWeeks: null`; the books document hours/minutes but no agreed weekly conversion basis.
- Align UX profile/modules with book config and published artifacts.
- Replace provisional migration notes with reproducible audit notes.
- Replace generic source references with direct book-source URLs and Issue #193.
- Regenerate `book-registry.json` and the deterministic debt report.

Debt movement:

| Item | Before | After |
|---|---:|---:|
| Empty `summary.ja` | 37 | 34 |
| Provisional notes | 37 | 34 |
| UX evidence candidates | 34 | 31 |
| Missing `lastReviewedAt` | 47 | 47 |
| Missing `reviewIssue` | 46 | 46 |

## Evidence-finalization split

Per the metadata policy, this first PR intentionally keeps `lastReviewedAt` and `reviewIssue` null. After this PR is merged and main CI, Pages, drift, and production rendering are confirmed, a second evidence-only PR will record the actual completion date and Issue #193.

## Files

- `docs/_data/catalog.json`
- `docs/publishing/book-registry.json` (generated)
- `docs/publishing/catalog-debt-report.json` (generated)

## Verification

- `npm ci` — pass, 0 vulnerabilities
- `npm run generate` — pass
- `npm run verify` — pass
  - catalog: 49 records / 7 paths
  - debt tests: 6 pass
  - production smoke unit tests: 7 pass
  - drift unit tests: 7 pass
  - Jekyll build: pass
  - Playwright: 39 pass across desktop/tablet/mobile; axe violations 0
- `node scripts/validate-ux-registry.js` — pass, 41 books
- `npm audit --audit-level=moderate` — pass, 0 vulnerabilities
- `git diff --check` — pass
- Source URLs — all checked on each repository's `main`
- Local reviewer: initial evidence/date and UX reproducibility findings fixed; follow-up found no High/Medium issue

## Follow-up

- #197 tracks missing Profile-required modules without falsifying current implementation values.
- The second #193 PR will finalize review evidence after production confirmation.
