### PR TITLE
catalog: finalize professional foundations review evidence

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -217,8 +217,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 193,
       "ux": {
         "profile": "B",
         "modules": {
@@ -235,7 +235,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#193で、book-configのProfile Bとmodulesを、公開トップ、第4章の検証手順、ケーススタディ、チェックリスト、図表索引の実体と照合済み。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
+        "2026-07-12のmetadata監査#193で、book-configのProfile Bとmodulesを、公開トップ、第4章の検証手順、ケーススタディ、チェックリスト、図表索引の実体と照合済み。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/evidence-based-engineering-book/blob/main/README.md",
@@ -246,7 +246,8 @@
         "https://github.com/itdojp/evidence-based-engineering-book/blob/main/docs/appendices/figure-index/index.md",
         "https://github.com/itdojp/evidence-based-engineering-book/blob/main/docs/appendices/case-studies/index.md",
         "docs/professional-foundations.md",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/198"
       ]
     },
     {
@@ -294,8 +295,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 193,
       "ux": {
         "profile": "A",
         "modules": {
@@ -312,7 +313,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
+        "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/issue-driven-work-book/blob/main/README.md",
@@ -324,7 +325,8 @@
         "https://github.com/itdojp/issue-driven-work-book/blob/main/docs/appendices/case-studies/index.md",
         "https://github.com/itdojp/issue-driven-work-book/blob/main/LICENSE.md",
         "docs/professional-foundations.md",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/198"
       ]
     },
     {
@@ -372,8 +374,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 193,
       "ux": {
         "profile": "B",
         "modules": {
@@ -390,7 +392,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引は未実装。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
+        "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引は未実装。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/engineering-documentation-book/blob/main/README.md",
@@ -401,7 +403,8 @@
         "https://github.com/itdojp/engineering-documentation-book/blob/main/docs/appendices/checklists/index.md",
         "https://github.com/itdojp/engineering-documentation-book/blob/main/docs/appendices/glossary/index.md",
         "docs/professional-foundations.md",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/198"
       ]
     },
     {

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -191,7 +191,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引は未実装。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
+      "notes": "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引は未実装。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
     },
     "ethereum-learning-bootcamp": {
       "repo": "itdojp/ethereum-learning-bootcamp",
@@ -223,7 +223,7 @@
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査#193で、book-configのProfile Bとmodulesを、公開トップ、第4章の検証手順、ケーススタディ、チェックリスト、図表索引の実体と照合済み。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
+      "notes": "2026-07-12のmetadata監査#193で、book-configのProfile Bとmodulesを、公開トップ、第4章の検証手順、ケーススタディ、チェックリスト、図表索引の実体と照合済み。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
     },
     "formal-methods-book": {
       "repo": "itdojp/formal-methods-book",
@@ -335,7 +335,7 @@
         "legalNotice": true,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。レビュー完了日とIssue証跡はmerge後確認を終えるまでnullを維持する。"
+      "notes": "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
     },
     "IT-engineer-communication-book": {
       "repo": "itdojp/IT-engineer-communication-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -108,7 +108,7 @@
       ]
     },
     "missingLastReviewedAt": {
-      "count": 47,
+      "count": 44,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -128,17 +128,14 @@
         "computational-physicalism-book",
         "cs-visionaries-book",
         "disaster-recovery-bcp-guide",
-        "engineering-documentation-book",
         "enterprise-cloud-architecture-guide",
         "ethereum-learning-bootcamp",
-        "evidence-based-engineering-book",
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
         "incident-response-basics-book",
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
-        "issue-driven-work-book",
         "it-infra-security-guide-book",
         "it-infra-software-essentials-book",
         "kubernetes-basics-book",
@@ -160,7 +157,7 @@
       ]
     },
     "missingReviewIssue": {
-      "count": 46,
+      "count": 43,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -179,17 +176,14 @@
         "computational-physicalism-book",
         "cs-visionaries-book",
         "disaster-recovery-bcp-guide",
-        "engineering-documentation-book",
         "enterprise-cloud-architecture-guide",
         "ethereum-learning-bootcamp",
-        "evidence-based-engineering-book",
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
         "incident-response-basics-book",
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
-        "issue-driven-work-book",
         "it-infra-security-guide-book",
         "it-infra-software-essentials-book",
         "kubernetes-basics-book",
@@ -632,7 +626,7 @@
         {
           "identifier": "cloud-infra-handbook",
           "path": "docs/_data/catalog.json",
-          "line": 3117,
+          "line": 3120,
           "column": 22
         }
       ]


### PR DESCRIPTION
## Summary

Closes #193 after the metadata PR's production verification.

PR #198 intentionally left review evidence null. It has now been merged and verified on main, GitHub Pages, production smoke, Pages drift, and the live `/books/` page. This PR records the actual completion date and review Issue for the three audited Professional Foundations books.

## Evidence recorded

- `lastReviewedAt`: `2026-07-12`
- `reviewIssue`: `193`
- Add PR #198 to `sourceRefs`
- Replace the temporary pre-merge note with the completed main/Pages/drift/production evidence

## Prior production evidence

- PR #198 merge: `6617c13203918f580ec84a3fed3d246e80f71fab`
- Main validation: `29168268801` — success
- Deploy Pages / production smoke: `29168268785` — success
- Pages drift: `29168310453` — success
- `/build-info.json`: merge SHA matched main
- `/books/`: HTTP 200, 49 cards, all three new summaries verified

## Debt movement

- Missing `lastReviewedAt`: 47 → 44
- Missing `reviewIssue`: 46 → 43

## Verification

- `npm ci` — pass, 0 vulnerabilities
- `npm run generate` — pass
- `npm run verify` — pass; Playwright 39
- `node scripts/validate-ux-registry.js` — pass, 41 books
- `npm audit --audit-level=moderate` — pass
- `git diff --check` — pass
