### PR TITLE
catalog: address post-merge English review feedback

### DIFF
--- a/scripts/catalog-utils.mjs
+++ b/scripts/catalog-utils.mjs
@@ -130,7 +130,7 @@ export function validateCatalog(catalog) {
     if (book.englishPagesUrl !== null && (typeof book.englishPagesUrl !== 'string' || !englishPagesRe.test(book.englishPagesUrl))) {
       errors.push(`${prefix}.englishPagesUrl is invalid`);
     }
-    if ((book.languages || []).includes('en') && !book.englishPagesUrl) {
+    if (book.status !== 'planned' && (book.languages || []).includes('en') && !book.englishPagesUrl) {
       errors.push(`${prefix}: English-language book must define englishPagesUrl`);
     }
     if (book.englishPagesUrl && !(book.languages || []).includes('en')) {
@@ -178,6 +178,7 @@ export function validateCatalog(catalog) {
     if (book.status === 'planned') {
       if (book.repoVisibility !== 'not-created') errors.push(`${prefix}: planned book must use repoVisibility=not-created`);
       if (book.pagesUrl !== null) errors.push(`${prefix}: planned book must not define pagesUrl`);
+      if (book.englishPagesUrl !== null) errors.push(`${prefix}: planned book must not define englishPagesUrl`);
       if (book.publicationScope !== 'planned') errors.push(`${prefix}: planned book must use publicationScope=planned`);
     }
     if (book.status === 'published') {

--- a/scripts/test-catalog-fixtures.mjs
+++ b/scripts/test-catalog-fixtures.mjs
@@ -70,6 +70,20 @@ const englishUrlCases = [
     name: 'englishPagesUrl on an invalid host',
     mutate: (book) => { book.languages = ['ja', 'en']; book.englishPagesUrl = 'https://example.com/book-one/en/'; },
     mustContain: 'englishPagesUrl is invalid'
+  },
+  {
+    name: 'planned book with englishPagesUrl',
+    mutate: (book) => {
+      book.status = 'planned';
+      book.repoVisibility = 'not-created';
+      book.pagesUrl = null;
+      book.publicationScope = 'planned';
+      book.countingGroup = 'planned';
+      book.countedInMainLineup = false;
+      book.languages = ['en'];
+      book.englishPagesUrl = 'https://itdojp.github.io/book-one/en/';
+    },
+    mustContain: 'planned book must not define englishPagesUrl'
   }
 ];
 for (const testCase of englishUrlCases) {
@@ -84,6 +98,27 @@ for (const testCase of englishUrlCases) {
   } else {
     console.log(`✅ inline fixture invalid as expected: ${testCase.name}`);
   }
+}
+
+const plannedEnglishCatalog = structuredClone(validCatalog);
+Object.assign(plannedEnglishCatalog.books[0], {
+  status: 'planned',
+  repoVisibility: 'not-created',
+  pagesUrl: null,
+  englishPagesUrl: null,
+  publicationScope: 'planned',
+  countingGroup: 'planned',
+  countedInMainLineup: false,
+  languages: ['en']
+});
+plannedEnglishCatalog.expectedCounts = { mainLineup: 1, planned: 1, relatedIndependent: 0 };
+const plannedEnglishErrors = validateCatalog(plannedEnglishCatalog);
+if (plannedEnglishErrors.length > 0) {
+  failed++;
+  console.error('❌ inline fixture expectation failed: planned English book without URL');
+  console.error(plannedEnglishErrors.join('\n'));
+} else {
+  console.log('✅ inline fixture valid as expected: planned English book without URL');
 }
 
 if (failed > 0) process.exit(1);

--- a/tests/smoke-production.test.mjs
+++ b/tests/smoke-production.test.mjs
@@ -4,12 +4,15 @@ import { createServer } from 'node:http';
 import { join } from 'node:path';
 import { test } from 'node:test';
 
+import catalog from '../docs/_data/catalog.json' with { type: 'json' };
 import { runProductionSmoke } from '../scripts/smoke-production.mjs';
 import { createBuildInfo, writeBuildInfo } from '../scripts/write-build-info.mjs';
 
 const SHA = '1234567890abcdef1234567890abcdef12345678';
 const OTHER_SHA = 'abcdef1234567890abcdef1234567890abcdef12';
 const basePath = '/it-engineer-knowledge-architecture/';
+const BOOK_COUNT = catalog.books.length;
+const PATH_COUNT = catalog.learningPaths.length;
 
 function page(title, content = '') {
   return `<!doctype html><html><body><nav aria-label="主要ナビゲーション"></nav><main id="main-content"><h1>${title}</h1>${content}</main></body></html>`;
@@ -38,9 +41,9 @@ async function startSite(options = {}) {
         'ITエンジニア知識アーキテクチャ',
         `<a href="${basePath}books/">books</a><a href="${basePath}paths/">paths</a><a href="${basePath}en/">en</a>${options.oldMarker || ''}`
       ),
-      'books/': page('書籍一覧', '<article data-book-card></article>'.repeat(options.cardCount ?? 49)),
-      'paths/': page('学習パス', '<article class="path-card"></article>'.repeat(options.pathCount ?? 7)),
-      'en/': page('English Catalog', '<tr data-en-book></tr>'.repeat(options.enBookCount ?? 49)),
+      'books/': page('書籍一覧', '<article data-book-card></article>'.repeat(options.cardCount ?? BOOK_COUNT)),
+      'paths/': page('学習パス', '<article class="path-card"></article>'.repeat(options.pathCount ?? PATH_COUNT)),
+      'en/': page('English Catalog', '<tr data-en-book></tr>'.repeat(options.enBookCount ?? BOOK_COUNT)),
       '404.html': page('ページが見つかりません')
     };
     if (relative === 'build-info.json') {
@@ -129,12 +132,12 @@ test('production smoke passes all required pages and writes reports', async () =
 
 
 test('production smoke detects an English catalog count mismatch', async () => {
-  await withSite({ enBookCount: 48 }, async (site, output) => {
+  await withSite({ enBookCount: BOOK_COUNT - 1 }, async (site, output) => {
     const report = await runProductionSmoke(config(site, output));
     assert.equal(report.ok, false);
     const english = report.endpoints.find((endpoint) => endpoint.label === '/en/');
-    assert.equal(english.markers.enBookCount, 48);
-    assert.match(english.errors.join('\n'), /English catalog books 48, expected 49/);
+    assert.equal(english.markers.enBookCount, BOOK_COUNT - 1);
+    assert.match(english.errors.join('\n'), new RegExp(`English catalog books ${BOOK_COUNT - 1}, expected ${BOOK_COUNT}`));
   });
 });
 


### PR DESCRIPTION
## 概要

PR #200 のマージ直前に投稿された2件の Codex インラインレビューを、後続PRとして反映します。マージ後に未解決コメントを検知したため、Issue #194 の完了条件に含めて是正します。

## 変更内容

- planned な英語書籍は englishPagesUrl: null を許容する
- planned 書籍に英語URLが設定された場合は検証エラーにする
- 上記の正・負フィクスチャを追加する
- production smoke の書籍数・学習パス数を catalog から導出し、固定値 49 / 7 を除去する

## 検証

- npm run verify
- npm audit
- npm run test:fixtures
- node --test tests/smoke-production.test.mjs
- git diff --check

Refs #194
Follow-up to #200
