### PR TITLE
ci: update actions to Node.js 24 majors

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure Pages
         uses: actions/configure-pages@v6
@@ -67,10 +67,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout deployed revision
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload production smoke report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: production-smoke-${{ github.run_id }}-${{ github.run_attempt }}
           path: tmp/production-smoke

--- a/.github/workflows/pages-drift-check.yml
+++ b/.github/workflows/pages-drift-check.yml
@@ -32,7 +32,7 @@ jobs:
       DRIFT_REPORT_MARKDOWN: tmp/pages-drift/report.md
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload drift report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pages-drift-${{ github.run_id }}-${{ github.run_attempt }}
           path: tmp/pages-drift

--- a/.github/workflows/pages-visual-check.yml
+++ b/.github/workflows/pages-visual-check.yml
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pages-visual-check
           path: tmp/pages-visual-check

--- a/.github/workflows/quality-sprint-reminder.yml
+++ b/.github/workflows/quality-sprint-reminder.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create targeted quality sprint issue (idempotent)
         env:

--- a/.github/workflows/update-book-status.yml
+++ b/.github/workflows/update-book-status.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: チェックアウト
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -37,7 +37,7 @@ jobs:
           node scripts/generate-progress-report.js
 
       - name: 進捗レポートをartifact保存
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: book-status-report
           path: |

--- a/.github/workflows/update-unification-progress.yml
+++ b/.github/workflows/update-unification-progress.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate dashboard artifact
         env:
@@ -107,7 +107,7 @@ jobs:
           PY
 
       - name: Upload dashboard artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: unification-progress
           path: tmp/unification-progress.md

--- a/.github/workflows/validate-learning-paths.yml
+++ b/.github/workflows/validate-learning-paths.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: チェックアウト
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Ruby設定
         uses: ruby/setup-ruby@v1
@@ -64,7 +64,7 @@ jobs:
         run: gem install jekyll -v 4.4.1
 
       - name: Node.js設定
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -88,12 +88,12 @@ jobs:
             -path './.site' -prune -o \
             -path './test-results' -prune -o \
             -path './playwright-report' -prune -o \
-            -name "*.md" -print | while read file; do
+            -name "*.md" -print | while read -r file; do
             if ! grep -q "\[.*\](.*\.md)" "$file"; then
               continue
             fi
             echo "チェック中: $file"
-            grep -oE "\[.*\]\([^)]*\.md[^)]*\)" "$file" | while read link; do
+            grep -oE "\[.*\]\([^)]*\.md[^)]*\)" "$file" | while read -r link; do
               path=$(echo "$link" | sed -E 's/.*\(([^)]*)\).*/\1/')
 
               # 外部リンク（http/https）はファイル存在チェックの対象外
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: チェックアウト
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: YAMLlint設定
         run: |
@@ -138,7 +138,7 @@ jobs:
       - name: YAML構文チェック
         run: |
           echo "📄 YAML構文チェック中..."
-          find . -name "*.yml" -o -name "*.yaml" | xargs yamllint -d '{extends: relaxed, rules: {line-length: disable}}'
+          find . \( -name "*.yml" -o -name "*.yaml" \) -print0 | xargs -0 yamllint -d '{extends: relaxed, rules: {line-length: disable}}'
           echo "✅ YAML構文チェック通過"
 
   generate-stats:
@@ -148,10 +148,10 @@ jobs:
 
     steps:
       - name: チェックアウト
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Node.js設定
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -183,7 +183,7 @@ jobs:
           NODE
 
       - name: 統計をアーティファクトとして保存
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: learning-path-stats
           path: stats.md

--- a/.github/workflows/youtube_sync.yml
+++ b/.github/workflows/youtube_sync.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
## 概要

GitHub ActionsのNode.js 20 action runtime非推奨警告を解消するため、対象actionをNode.js 24対応majorへ更新します。

## 変更内容

- actions/checkout: v4 → v6
- actions/setup-node: v4 → v6
- actions/setup-python: v4 → v6
- actions/upload-artifact: v4 → v6
- actionlintが検出したshell safety指摘を最小修正（read -r、find/xargsのNUL区切り）
- trigger、permissions、workflowロジックは変更しない
- 既に対応済みのPages actionsとruby/setup-rubyは変更しない

## 互換性確認

checkout v6のcredential persistence変更について、対象workflowにはcheckout後のgit操作・Docker container actionがないことを確認しました。

## 検証

- actionlint 1.7.12（全8 workflow）
- YAML parse（全8 workflow）
- npm ci
- npm run verify（Playwright 45件を含む）
- npm audit --omit=dev --omit=optional（0件）
- git diff --check

Closes #196
