### PR TITLE
catalog: Professional Foundations 2冊のQuality Sprint

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "updatedAt": "2026-07-11",
+  "updatedAt": "2026-07-12",
   "sourcePolicy": {
     "canonical": "docs/_data/catalog.json",
     "derivedFiles": [
@@ -434,52 +434,60 @@
         "professional-foundations"
       ],
       "levels": [
-        "all-levels"
+        "beginner",
+        "intermediate"
       ],
       "roles": [
         "all-engineers"
       ],
       "audiences": [
-        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+        "開発 / 運用に参加し始めた新人エンジニア",
+        "業務委託 / 外部メンバーを含むチーム"
       ],
       "summary": {
-        "ja": "",
-        "en": "Introduces everyday security and privacy practice around secrets, permissions, and responsible data handling."
+        "ja": "開発・運用に参加し始めたエンジニアが、秘密情報、認証、最小権限、データ分類、誤公開防止、漏えい疑いの初動を学び、テンプレートとチェックリストをレビューやリリース前確認へ組み込むための基礎実務書です。",
+        "en": "Introduces early-career development and operations practitioners to secrets, authentication, least privilege, data classification, accidental disclosure prevention, and incident first response, with reusable templates and checklists for reviews and releases."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "incident-response-basics-book"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 205,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
+          "figureIndex": false,
           "legalNotice": false,
-          "glossary": false
+          "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がないためfigureIndex=falseとし、必須module debtは#197で追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/README.md",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/BOOK-PROPOSAL.md",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/book-config.json",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/docs/index.md",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/docs/_data/navigation.yml",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/docs/appendices/checklists/index.md",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/docs/appendices/templates/index.md",
+        "docs/professional-foundations.md",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/205"
       ]
     },
     {
@@ -504,17 +512,23 @@
         "professional-foundations"
       ],
       "levels": [
-        "all-levels"
+        "beginner",
+        "intermediate"
       ],
       "roles": [
-        "all-engineers"
+        "software-engineer",
+        "infrastructure-engineer",
+        "sre",
+        "engineering-manager"
       ],
       "audiences": [
-        "全レベル / 仕事の進め方・調査・ドキュメント・セキュリティ基礎"
+        "インシデント対応の一次受け、SRE、運用リード",
+        "障害時の切り分け・状況共有・復旧判断を標準化したい開発 / 運用担当",
+        "ポストモーテムを改善サイクルにつなげたいテックリードや管理者"
       ],
       "summary": {
-        "ja": "",
-        "en": "Provides a reusable incident response pattern from initial triage through communication, recovery, and postmortem review."
+        "ja": "インシデント対応の一次受け・運用担当者が、症状と影響の切り分け、証跡収集、Severity、状況共有、復旧・ロールバック、エスカレーション、ポストモーテムを一連の再現可能な運用として実践するための基礎書です。",
+        "en": "Provides first responders and operations practitioners with a repeatable flow for triage, evidence collection, severity assessment, communication, recovery and rollback, escalation, and postmortems."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
@@ -524,32 +538,36 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 205,
       "ux": {
         "profile": "B",
         "modules": {
-          "quickStart": false,
-          "readingGuide": false,
+          "quickStart": true,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
+          "figureIndex": false,
           "legalNotice": false,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がないためfigureIndex=falseとし、必須module debtは#197で追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/README.md",
+        "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/BOOK-PROPOSAL.md",
+        "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/book-config.json",
+        "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/docs/index.md",
+        "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/docs/_data/navigation.yml",
+        "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/docs/appendices/checklists/index.md",
+        "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/docs/appendices/templates/index.md",
+        "docs/professional-foundations.md",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/205"
       ]
     },
     {

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -487,7 +487,8 @@
         "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/docs/appendices/checklists/index.md",
         "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/docs/appendices/templates/index.md",
         "docs/professional-foundations.md",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/205"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/205",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/206"
       ]
     },
     {
@@ -567,7 +568,8 @@
         "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/docs/appendices/checklists/index.md",
         "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/docs/appendices/templates/index.md",
         "docs/professional-foundations.md",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/205"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/205",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/206"
       ]
     },
     {

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "updatedAt": "2026-07-11",
+  "updatedAt": "2026-07-12",
   "generatedFrom": "docs/_data/catalog.json",
   "modulesCatalog": [
     "quickStart",
@@ -310,16 +310,16 @@
       "pages": "https://itdojp.github.io/incident-response-basics-book/",
       "profile": "B",
       "modules": {
-        "quickStart": false,
-        "readingGuide": false,
+        "quickStart": true,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
+        "figureIndex": false,
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がないためfigureIndex=falseとし、必須module debtは#197で追跡する。"
     },
     "issue-driven-work-book": {
       "repo": "itdojp/issue-driven-work-book",
@@ -583,15 +583,15 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
+        "figureIndex": false,
         "legalNotice": false,
-        "glossary": false
+        "glossary": true
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がないためfigureIndex=falseとし、必須module debtは#197で追跡する。"
     },
     "small-webapp-software-design-book": {
       "repo": "itdojp/small-webapp-software-design-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -10,7 +10,7 @@
   },
   "debt": {
     "emptySummaryJa": {
-      "count": 34,
+      "count": 32,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -30,7 +30,6 @@
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
-        "incident-response-basics-book",
         "it-infra-security-guide-book",
         "it-infra-software-essentials-book",
         "kubernetes-basics-book",
@@ -42,7 +41,6 @@
         "podman-book",
         "practical-auth-book",
         "proxmox_book",
-        "security-privacy-literacy-book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
         "theoretical-computer-science-textbook"
@@ -108,7 +106,7 @@
       ]
     },
     "missingLastReviewedAt": {
-      "count": 44,
+      "count": 42,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -133,7 +131,6 @@
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
-        "incident-response-basics-book",
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
         "it-infra-security-guide-book",
@@ -149,7 +146,6 @@
         "practical-auth-book",
         "practical-security-infrastructure-guide",
         "proxmox_book",
-        "security-privacy-literacy-book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
         "theoretical-computer-science-prerequisites-book",
@@ -157,7 +153,7 @@
       ]
     },
     "missingReviewIssue": {
-      "count": 43,
+      "count": 41,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -181,7 +177,6 @@
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
-        "incident-response-basics-book",
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
         "it-infra-security-guide-book",
@@ -197,7 +192,6 @@
         "practical-auth-book",
         "practical-security-infrastructure-guide",
         "proxmox_book",
-        "security-privacy-literacy-book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
         "theoretical-computer-science-prerequisites-book",
@@ -205,7 +199,7 @@
       ]
     },
     "provisionalNotes": {
-      "count": 34,
+      "count": 32,
       "books": [
         {
           "id": "BioinformaticsGuide-book",
@@ -351,14 +345,6 @@
           ]
         },
         {
-          "id": "incident-response-basics-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
           "id": "it-infra-security-guide-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
@@ -432,14 +418,6 @@
         },
         {
           "id": "proxmox_book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
-          "id": "security-privacy-literacy-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
             "日本語個別概要はREADME公開カタログ上で未記載。",
@@ -525,7 +503,7 @@
       ]
     },
     "uxEvidenceCandidates": {
-      "count": 31,
+      "count": 29,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -546,7 +524,6 @@
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
-        "incident-response-basics-book",
         "it-infra-security-guide-book",
         "it-infra-software-essentials-book",
         "negotiation-for-engineers-book",
@@ -554,7 +531,6 @@
         "podman-book",
         "practical-auth-book",
         "proxmox_book",
-        "security-privacy-literacy-book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
         "theoretical-computer-science-textbook"


### PR DESCRIPTION
## 概要

Closes #205
Parent: #187
Follow-up: #197

Professional Foundationsの次の2冊を、各書籍の固定main SHA、公開Pages、CI、企画・設定・本文・付録の根拠に基づいて棚卸ししました。

- `security-privacy-literacy-book`
- `incident-response-basics-book`

## 変更内容

- `summary.ja`を各99字・104字で補完し、`summary.en`を現行構成へ整合
- 対象読者、levels、rolesを各書籍とProfessional Foundations実装ガイドへ整合
- 根拠がない`estimatedWeeks`とcatalog prerequisiteは未設定を維持
- 正本ガイドの読書順に基づきsecurity/privacy本からincident response本への`recommendedAfter`を設定
- UX modulesを公開実体と照合し、存在しない専用図表索引を`false`へ修正
- `lastReviewedAt` / `reviewIssue` / concrete notes / 固定SHAの`sourceRefs`を追加
- 生成registryとdeterministic debt reportを更新

Profile B必須moduleの不足追跡・再増加防止は、テーマを分けて#197の別PRで実装します。

## Debt差分

- empty `summary.ja`: 34 → 32
- missing `lastReviewedAt`: 44 → 42
- missing `reviewIssue`: 43 → 41
- provisional notes: 34 → 32
- UX evidence candidates: 31 → 29
- reader-view leaks: 0 → 0

## 検証

- [x] `npm ci`（0 vulnerabilities）
- [x] `npm run generate`
- [x] `npm run verify`
  - catalog 49 records / learning paths 7
  - catalog debt tests 7
  - production smoke tests 8
  - Pages drift tests 7
  - Playwright 45 / 45
- [x] `node scripts/validate-ux-registry.js`（41 books）
- [x] `npm audit --audit-level=moderate`（0 vulnerabilities）
- [x] sourceRefs 16 external URLs HTTP 200
- [x] `/books/`と`/en/`のローカルbuildに両概要を確認
- [x] `git diff --check`

## レビュー観点

- `recommendedAfter`と、必須ではない`prerequisites`の分離が妥当か
- index内の読み方・用語・初動フローをmodule実体として扱う判断がpolicyに整合するか
- 専用図表索引を推測でtrueにせず、#197のdebtとして分離しているか
