### PR TITLE
catalog: audit core infrastructure foundations

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -594,52 +594,62 @@
         "core-infra-foundations"
       ],
       "levels": [
-        "junior",
+        "beginner",
         "intermediate"
       ],
       "roles": [
-        "infrastructure-engineer"
+        "infrastructure-engineer",
+        "software-engineer"
       ],
       "audiences": [
-        "新人〜中級者（経験0–2年）/ ITインフラの土台となる必修知識"
+        "Linux未経験のIT系学生",
+        "他業種からITインフラ職への転職を目指す人",
+        "インフラの知識を補強したいソフトウェアエンジニア"
       ],
       "summary": {
-        "ja": "",
-        "en": "Builds Linux infrastructure fundamentals for modern operations, including systems, networking, process management, and security basics."
+        "ja": "Linux未経験者やインフラ知識を補強したい開発者が、OS、ファイルシステム、プロセス、権限、TCP/IP、コンテナ、クラウド、監視、IaCを原理と演習から学び、現代的なLinux基盤の全体像を説明・操作できるようにする入門書です。",
+        "en": "Guides Linux beginners and software engineers through operating systems, filesystems, processes, permissions, networking, containers, cloud infrastructure, observability, and IaC, combining underlying principles with hands-on exercises."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "it-infra-software-essentials-book"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 208,
       "ux": {
-        "profile": "B",
+        "profile": "A",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
-          "checklistPack": true,
-          "troubleshootingFlow": true,
+          "readingGuide": true,
+          "checklistPack": false,
+          "troubleshootingFlow": false,
           "conceptMap": false,
-          "figureIndex": true,
-          "legalNotice": false,
-          "glossary": false
+          "figureIndex": false,
+          "legalNotice": true,
+          "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "linux-infra-textbook を置換（旧版はアーカイブ）",
-        "日本語個別概要はREADME公開カタログ上で未記載。"
+        "linux-infra-textbookを置換する現行版。2026-07-12のmetadata監査#208で、source main e50b187543ae9203fa9797c3d829f4fda0df1a29のREADME、企画書、book-config、公開トップ、導入、用語集を照合し、対象読者、Profile A、modulesを確定。学習時間は時間単位のみのため週換算せず、公開読者向けQuick Startがない必須module debtは#208で追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/README.md",
+        "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/BOOK-PROPOSAL.md",
+        "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/book-config.json",
+        "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/index.md",
+        "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/introduction/index.md",
+        "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/glossary.md",
+        "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/_data/navigation.yml",
+        "docs/_data/catalog.json",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208"
       ]
     },
     {
@@ -668,49 +678,61 @@
         "intermediate"
       ],
       "roles": [
-        "infrastructure-engineer"
+        "infrastructure-engineer",
+        "sre"
       ],
       "audiences": [
-        "新人〜中級者（経験0–2年）/ ITインフラの土台となる必修知識"
+        "自動化やクラウド連携に必要なソフトウェア基礎を効率的に学びたいインフラエンジニア",
+        "設定ファイル、スクリプト、API連携の基本を短期間で身につけたいインフラ担当者",
+        "開発者との連携を改善し、DevOpsを実践したいエンジニア"
       ],
       "summary": {
-        "ja": "",
-        "en": "Explains the software concepts infrastructure engineers need for packages, code reading, APIs, databases, and runtime behavior."
+        "ja": "インフラ運用・構築に携わるエンジニアが、YAML/JSON、シェルとPython、REST API、Git、正規表現を実例から学び、設定管理、定型作業の自動化、クラウドサービス連携を安全にレビュー可能な形で進めるための基礎書です。",
+        "en": "Teaches infrastructure practitioners the software foundations needed for configuration and automation, including YAML/JSON, shell and Python scripting, REST APIs, Git, and regular expressions, with review gates for safe operational use."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "IT-infra-book"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 208,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
-          "troubleshootingFlow": true,
+          "troubleshootingFlow": false,
           "conceptMap": false,
-          "figureIndex": true,
+          "figureIndex": false,
           "legalNotice": false,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査#208と書籍側#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#208で追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/README.md",
+        "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/book-config.json",
+        "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/index.md",
+        "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/_data/navigation.yml",
+        "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/chapters/chapter02/index.md",
+        "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/chapters/chapter03/index.md",
+        "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/chapters/chapter04/index.md",
+        "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/chapters/chapter05/index.md",
+        "docs/_data/catalog.json",
+        "https://github.com/itdojp/it-infra-software-essentials-book/issues/126",
+        "https://github.com/itdojp/it-infra-software-essentials-book/pull/127",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208"
       ]
     },
     {
@@ -735,53 +757,66 @@
         "core-infra-foundations"
       ],
       "levels": [
-        "junior",
-        "intermediate"
+        "intermediate",
+        "advanced"
       ],
       "roles": [
-        "infrastructure-engineer"
+        "infrastructure-engineer",
+        "sre",
+        "backend-engineer",
+        "architect"
       ],
       "audiences": [
-        "新人〜中級者（経験0–2年）/ ITインフラの土台となる必修知識"
+        "オンプレミスまたはクラウドのインフラ設計・構築・運用に携わるエンジニア",
+        "インフラ層の理解を深めたいSRE、DevOps、バックエンドエンジニア",
+        "技術選定やアーキテクチャレビューを担うテックリード、アーキテクト"
       ],
       "summary": {
-        "ja": "",
-        "en": "Organizes the design principles behind protocols, networks, operating systems, and storage for infrastructure engineers."
+        "ja": "インフラ設計・構築・運用に携わるエンジニアやアーキテクトが、ネットワーク、OS、ストレージ、仮想化、自動化、セキュリティ、高可用性をベンダー非依存の原理で整理し、技術選択とアーキテクチャレビューを説明可能にするための設計実務書です。",
+        "en": "Organizes vendor-neutral principles for networks, operating systems, storage, virtualization, automation, security, and high availability so infrastructure engineers and architects can make and review defensible technology choices."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "IT-infra-troubleshooting-book"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 208,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
+          "figureIndex": false,
           "legalNotice": false,
-          "glossary": false
+          "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査#208と書籍側#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#208で追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/README.md",
+        "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/book-config.json",
+        "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/docs/index.md",
+        "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/docs/introduction/index.md",
+        "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/docs/_data/navigation.yml",
+        "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/docs/appendices/appendix01/index.md",
+        "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/docs/appendices/appendix02/index.md",
+        "docs/_data/catalog.json",
+        "https://github.com/itdojp/IT-infra-book/issues/155",
+        "https://github.com/itdojp/IT-infra-book/pull/156",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208"
       ]
     },
     {

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -648,7 +648,6 @@
         "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/introduction/index.md",
         "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/glossary.md",
         "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/_data/navigation.yml",
-        "docs/_data/catalog.json",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/209"
       ]
@@ -730,7 +729,6 @@
         "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/chapters/chapter03/index.md",
         "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/chapters/chapter04/index.md",
         "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/docs/chapters/chapter05/index.md",
-        "docs/_data/catalog.json",
         "https://github.com/itdojp/it-infra-software-essentials-book/issues/126",
         "https://github.com/itdojp/it-infra-software-essentials-book/pull/127",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208",
@@ -815,7 +813,6 @@
         "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/docs/_data/navigation.yml",
         "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/docs/appendices/appendix01/index.md",
         "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/docs/appendices/appendix02/index.md",
-        "docs/_data/catalog.json",
         "https://github.com/itdojp/IT-infra-book/issues/155",
         "https://github.com/itdojp/IT-infra-book/pull/156",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208",

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -649,7 +649,8 @@
         "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/glossary.md",
         "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/docs/_data/navigation.yml",
         "docs/_data/catalog.json",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/209"
       ]
     },
     {
@@ -732,7 +733,8 @@
         "docs/_data/catalog.json",
         "https://github.com/itdojp/it-infra-software-essentials-book/issues/126",
         "https://github.com/itdojp/it-infra-software-essentials-book/pull/127",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/209"
       ]
     },
     {
@@ -816,7 +818,8 @@
         "docs/_data/catalog.json",
         "https://github.com/itdojp/IT-infra-book/issues/155",
         "https://github.com/itdojp/IT-infra-book/pull/156",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/208",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/209"
       ]
     },
     {

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -638,7 +638,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "linux-infra-textbookを置換する現行版。2026-07-12のmetadata監査#208で、source main e50b187543ae9203fa9797c3d829f4fda0df1a29のREADME、企画書、book-config、公開トップ、導入、用語集を照合し、対象読者、Profile A、modulesを確定。学習時間は時間単位のみのため週換算せず、公開読者向けQuick Startがない必須module debtは#208で追跡する。"
+        "linux-infra-textbookを置換する現行版。2026-07-12のmetadata監査#208で、source main e50b187543ae9203fa9797c3d829f4fda0df1a29のREADME、企画書、book-config、公開トップ、導入、用語集を照合し、対象読者、Profile A、modulesを確定。学習時間は時間単位のみのため週換算せず、公開読者向けQuick Startがない必須module debtは#210で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/linux-infra-textbook2/blob/e50b187543ae9203fa9797c3d829f4fda0df1a29/README.md",
@@ -718,7 +718,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#208と書籍側#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#208で追跡する。"
+        "2026-07-12のmetadata監査#208と書籍側#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#210で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/README.md",
@@ -803,7 +803,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#208と書籍側#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#208で追跡する。"
+        "2026-07-12のmetadata監査#208と書籍側#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#210で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/README.md",

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -718,7 +718,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#208と書籍側#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#210で追跡する。"
+        "2026-07-12のmetadata監査#208とitdojp/it-infra-software-essentials-book#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#210で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/it-infra-software-essentials-book/blob/fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7/README.md",
@@ -803,7 +803,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#208と書籍側#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#210で追跡する。"
+        "2026-07-12のmetadata監査#208とitdojp/IT-infra-book#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#210で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/IT-infra-book/blob/e132c9faeb7348f9656563c593abd9ffbb79dba1/README.md",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -367,7 +367,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査#208と書籍側#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#210で追跡する。"
+      "notes": "2026-07-12のmetadata監査#208とitdojp/IT-infra-book#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#210で追跡する。"
     },
     "it-infra-security-guide-book": {
       "repo": "itdojp/it-infra-security-guide-book",
@@ -399,7 +399,7 @@
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査#208と書籍側#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#210で追跡する。"
+      "notes": "2026-07-12のmetadata監査#208とitdojp/it-infra-software-essentials-book#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#210で追跡する。"
     },
     "IT-infra-troubleshooting-book": {
       "repo": "itdojp/IT-infra-troubleshooting-book",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -367,7 +367,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査#208と書籍側#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#208で追跡する。"
+      "notes": "2026-07-12のmetadata監査#208と書籍側#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#210で追跡する。"
     },
     "it-infra-security-guide-book": {
       "repo": "itdojp/it-infra-security-guide-book",
@@ -399,7 +399,7 @@
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査#208と書籍側#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#208で追跡する。"
+      "notes": "2026-07-12のmetadata監査#208と書籍側#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#210で追跡する。"
     },
     "IT-infra-troubleshooting-book": {
       "repo": "itdojp/IT-infra-troubleshooting-book",
@@ -479,7 +479,7 @@
         "legalNotice": true,
         "glossary": true
       },
-      "notes": "linux-infra-textbookを置換する現行版。2026-07-12のmetadata監査#208で、source main e50b187543ae9203fa9797c3d829f4fda0df1a29のREADME、企画書、book-config、公開トップ、導入、用語集を照合し、対象読者、Profile A、modulesを確定。学習時間は時間単位のみのため週換算せず、公開読者向けQuick Startがない必須module debtは#208で追跡する。"
+      "notes": "linux-infra-textbookを置換する現行版。2026-07-12のmetadata監査#208で、source main e50b187543ae9203fa9797c3d829f4fda0df1a29のREADME、企画書、book-config、公開トップ、導入、用語集を照合し、対象読者、Profile A、modulesを確定。学習時間は時間単位のみのため週換算せず、公開読者向けQuick Startがない必須module debtは#210で追跡する。"
     },
     "LogicalThinking-AI-Era-Guide": {
       "repo": "itdojp/LogicalThinking-AI-Era-Guide",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -359,15 +359,15 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
+        "figureIndex": false,
         "legalNotice": false,
-        "glossary": false
+        "glossary": true
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査#208と書籍側#155で、source main e132c9faeb7348f9656563c593abd9ffbb79dba1のREADME、book-config、公開トップ、導入、用語集、トラブルシューティング付録を照合し、対象読者、Profile B、modulesを確定。学習時間は時間単位のみのため週換算せず、専用図表索引がない必須module debtは#208で追跡する。"
     },
     "it-infra-security-guide-book": {
       "repo": "itdojp/it-infra-security-guide-book",
@@ -391,15 +391,15 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
-        "troubleshootingFlow": true,
+        "troubleshootingFlow": false,
         "conceptMap": false,
-        "figureIndex": true,
+        "figureIndex": false,
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査#208と書籍側#126で、source main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7のREADME、book-config、公開トップ、全5章を照合し、対象読者、Profile B、modulesを確定。READMEと公開トップの学習時間に差があるため週換算せず、専用トラブルシューティングフローと図表索引がない必須module debtは#208で追跡する。"
     },
     "IT-infra-troubleshooting-book": {
       "repo": "itdojp/IT-infra-troubleshooting-book",
@@ -468,18 +468,18 @@
     "linux-infra-textbook2": {
       "repo": "itdojp/linux-infra-textbook2",
       "pages": "https://itdojp.github.io/linux-infra-textbook2/",
-      "profile": "B",
+      "profile": "A",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
-        "checklistPack": true,
-        "troubleshootingFlow": true,
+        "readingGuide": true,
+        "checklistPack": false,
+        "troubleshootingFlow": false,
         "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
-        "glossary": false
+        "figureIndex": false,
+        "legalNotice": true,
+        "glossary": true
       },
-      "notes": "linux-infra-textbook を置換（旧版はアーカイブ）"
+      "notes": "linux-infra-textbookを置換する現行版。2026-07-12のmetadata監査#208で、source main e50b187543ae9203fa9797c3d829f4fda0df1a29のREADME、企画書、book-config、公開トップ、導入、用語集を照合し、対象読者、Profile A、modulesを確定。学習時間は時間単位のみのため週換算せず、公開読者向けQuick Startがない必須module debtは#208で追跡する。"
     },
     "LogicalThinking-AI-Era-Guide": {
       "repo": "itdojp/LogicalThinking-AI-Era-Guide",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -515,7 +515,7 @@
               "module": "figureIndex",
               "reason": "実ファイル監査で図版は存在するが専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 208,
-              "trackingIssue": 208
+              "trackingIssue": 210
             }
           ]
         },
@@ -563,13 +563,13 @@
               "module": "figureIndex",
               "reason": "実ファイル監査で図版は存在するが専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 208,
-              "trackingIssue": 208
+              "trackingIssue": 210
             },
             {
               "module": "troubleshootingFlow",
               "reason": "実ファイル監査で専用のトラブルシューティングフローが未実装であることを確認済み。一般的なレビューゲートを代用せず、根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 208,
-              "trackingIssue": 208
+              "trackingIssue": 210
             }
           ]
         },
@@ -581,7 +581,7 @@
               "module": "quickStart",
               "reason": "実ファイル監査で公開読者向けのQuick Startが未実装であることを確認済み。リポジトリ作業者向けQUICK-START.mdは読者向けmoduleとして扱わず、根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 208,
-              "trackingIssue": 208
+              "trackingIssue": 210
             }
           ]
         },

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -10,12 +10,11 @@
   },
   "debt": {
     "emptySummaryJa": {
-      "count": 32,
+      "count": 29,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
         "IT-engineer-communication-book",
-        "IT-infra-book",
         "IT-infra-troubleshooting-book",
         "LogicalThinking-AI-Era-Guide",
         "ai-agent-engineering-book",
@@ -31,11 +30,9 @@
         "github-guide-for-beginners-book",
         "github-workflow-book",
         "it-infra-security-guide-book",
-        "it-infra-software-essentials-book",
         "kubernetes-basics-book",
         "kubernetes-cluster-ops-book",
         "kubernetes-proxmox-to-cloud-book",
-        "linux-infra-textbook2",
         "negotiation-for-engineers-book",
         "pentest-learning-book",
         "podman-book",
@@ -106,12 +103,11 @@
       ]
     },
     "missingLastReviewedAt": {
-      "count": 42,
+      "count": 39,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
         "IT-engineer-communication-book",
-        "IT-infra-book",
         "IT-infra-troubleshooting-book",
         "LogicalThinking-AI-Era-Guide",
         "ai-agent-collaboration-book",
@@ -134,11 +130,9 @@
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
         "it-infra-security-guide-book",
-        "it-infra-software-essentials-book",
         "kubernetes-basics-book",
         "kubernetes-cluster-ops-book",
         "kubernetes-proxmox-to-cloud-book",
-        "linux-infra-textbook2",
         "negotiation-for-engineers-book",
         "next-generation-infrastructure-guide",
         "pentest-learning-book",
@@ -153,12 +147,11 @@
       ]
     },
     "missingReviewIssue": {
-      "count": 41,
+      "count": 38,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
         "IT-engineer-communication-book",
-        "IT-infra-book",
         "IT-infra-troubleshooting-book",
         "LogicalThinking-AI-Era-Guide",
         "ai-agent-collaboration-book",
@@ -180,11 +173,9 @@
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
         "it-infra-security-guide-book",
-        "it-infra-software-essentials-book",
         "kubernetes-basics-book",
         "kubernetes-cluster-ops-book",
         "kubernetes-proxmox-to-cloud-book",
-        "linux-infra-textbook2",
         "negotiation-for-engineers-book",
         "next-generation-infrastructure-guide",
         "pentest-learning-book",
@@ -199,7 +190,7 @@
       ]
     },
     "provisionalNotes": {
-      "count": 32,
+      "count": 29,
       "books": [
         {
           "id": "BioinformaticsGuide-book",
@@ -219,14 +210,6 @@
         },
         {
           "id": "IT-engineer-communication-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
-          "id": "IT-infra-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
             "日本語個別概要はREADME公開カタログ上で未記載。",
@@ -353,14 +336,6 @@
           ]
         },
         {
-          "id": "it-infra-software-essentials-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
           "id": "kubernetes-basics-book",
           "notes": [
             "日本語個別概要はREADME公開カタログ上で未記載。"
@@ -374,12 +349,6 @@
         },
         {
           "id": "kubernetes-proxmox-to-cloud-book",
-          "notes": [
-            "日本語個別概要はREADME公開カタログ上で未記載。"
-          ]
-        },
-        {
-          "id": "linux-infra-textbook2",
           "notes": [
             "日本語個別概要はREADME公開カタログ上で未記載。"
           ]
@@ -503,12 +472,11 @@
       ]
     },
     "uxEvidenceCandidates": {
-      "count": 29,
+      "count": 27,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
         "IT-engineer-communication-book",
-        "IT-infra-book",
         "IT-infra-troubleshooting-book",
         "LogicalThinking-AI-Era-Guide",
         "ai-agent-engineering-book",
@@ -525,7 +493,6 @@
         "github-guide-for-beginners-book",
         "github-workflow-book",
         "it-infra-security-guide-book",
-        "it-infra-software-essentials-book",
         "negotiation-for-engineers-book",
         "pentest-learning-book",
         "podman-book",
@@ -537,9 +504,21 @@
       ]
     },
     "missingRequiredUxModules": {
-      "count": 4,
-      "bookCount": 4,
+      "count": 8,
+      "bookCount": 7,
       "books": [
+        {
+          "id": "IT-infra-book",
+          "profile": "B",
+          "missingModules": [
+            {
+              "module": "figureIndex",
+              "reason": "実ファイル監査で図版は存在するが専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 208,
+              "trackingIssue": 208
+            }
+          ]
+        },
         {
           "id": "engineering-documentation-book",
           "profile": "B",
@@ -577,6 +556,36 @@
           ]
         },
         {
+          "id": "it-infra-software-essentials-book",
+          "profile": "B",
+          "missingModules": [
+            {
+              "module": "figureIndex",
+              "reason": "実ファイル監査で図版は存在するが専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 208,
+              "trackingIssue": 208
+            },
+            {
+              "module": "troubleshootingFlow",
+              "reason": "実ファイル監査で専用のトラブルシューティングフローが未実装であることを確認済み。一般的なレビューゲートを代用せず、根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 208,
+              "trackingIssue": 208
+            }
+          ]
+        },
+        {
+          "id": "linux-infra-textbook2",
+          "profile": "A",
+          "missingModules": [
+            {
+              "module": "quickStart",
+              "reason": "実ファイル監査で公開読者向けのQuick Startが未実装であることを確認済み。リポジトリ作業者向けQUICK-START.mdは読者向けmoduleとして扱わず、根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 208,
+              "trackingIssue": 208
+            }
+          ]
+        },
+        {
           "id": "security-privacy-literacy-book",
           "profile": "B",
           "missingModules": [
@@ -597,8 +606,8 @@
   },
   "gates": {
     "requiredUxModuleDebt": {
-      "baselineCount": 4,
-      "currentCount": 4,
+      "baselineCount": 8,
+      "currentCount": 8,
       "unapprovedCount": 0,
       "unapproved": [],
       "staleBaselineCount": 0,

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -7,7 +7,7 @@
       "module": "figureIndex",
       "reason": "実ファイル監査で図版は存在するが専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 208,
-      "trackingIssue": 208
+      "trackingIssue": 210
     },
     {
       "bookId": "engineering-documentation-book",
@@ -39,7 +39,7 @@
       "module": "figureIndex",
       "reason": "実ファイル監査で図版は存在するが専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 208,
-      "trackingIssue": 208
+      "trackingIssue": 210
     },
     {
       "bookId": "it-infra-software-essentials-book",
@@ -47,7 +47,7 @@
       "module": "troubleshootingFlow",
       "reason": "実ファイル監査で専用のトラブルシューティングフローが未実装であることを確認済み。一般的なレビューゲートを代用せず、根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 208,
-      "trackingIssue": 208
+      "trackingIssue": 210
     },
     {
       "bookId": "linux-infra-textbook2",
@@ -55,7 +55,7 @@
       "module": "quickStart",
       "reason": "実ファイル監査で公開読者向けのQuick Startが未実装であることを確認済み。リポジトリ作業者向けQUICK-START.mdは読者向けmoduleとして扱わず、根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 208,
-      "trackingIssue": 208
+      "trackingIssue": 210
     },
     {
       "bookId": "security-privacy-literacy-book",

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -2,6 +2,14 @@
   "schemaVersion": "1.0.0",
   "entries": [
     {
+      "bookId": "IT-infra-book",
+      "profile": "B",
+      "module": "figureIndex",
+      "reason": "実ファイル監査で図版は存在するが専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 208,
+      "trackingIssue": 208
+    },
+    {
       "bookId": "engineering-documentation-book",
       "profile": "B",
       "module": "figureIndex",
@@ -24,6 +32,30 @@
       "reason": "実ファイル監査で専用の用語導線が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 193,
       "trackingIssue": 197
+    },
+    {
+      "bookId": "it-infra-software-essentials-book",
+      "profile": "B",
+      "module": "figureIndex",
+      "reason": "実ファイル監査で図版は存在するが専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 208,
+      "trackingIssue": 208
+    },
+    {
+      "bookId": "it-infra-software-essentials-book",
+      "profile": "B",
+      "module": "troubleshootingFlow",
+      "reason": "実ファイル監査で専用のトラブルシューティングフローが未実装であることを確認済み。一般的なレビューゲートを代用せず、根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 208,
+      "trackingIssue": 208
+    },
+    {
+      "bookId": "linux-infra-textbook2",
+      "profile": "A",
+      "module": "quickStart",
+      "reason": "実ファイル監査で公開読者向けのQuick Startが未実装であることを確認済み。リポジトリ作業者向けQUICK-START.mdは読者向けmoduleとして扱わず、根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 208,
+      "trackingIssue": 208
     },
     {
       "bookId": "security-privacy-literacy-book",


### PR DESCRIPTION
## 変更内容

Core Infrastructure FoundationsのdisplayOrder順3冊を固定main SHAと公開Pagesで再監査し、正本カタログを更新します。

- linux-infra-textbook2
- it-infra-software-essentials-book
- IT-infra-book

各レコードについて、日本語・英語概要、対象読者、levels、roles、canonical学習順、レビュー証跡、UX profile/modules、監査notes、fixed-SHA sourceRefsを根拠ベースで確定しました。週換算できる根拠がないため estimatedWeeks は追加していません。

## 書籍側の先行修正

公開実態と source book-config.json が不一致だった2冊は、先に別Issue/PRで修正・merge・Pages確認済みです。

- itdojp/it-infra-software-essentials-book#126 / PR #127 / main fb371a68b4f82422efdd4b0e3507a6fb9c0d06d7
- itdojp/IT-infra-book#155 / PR #156 / main e132c9faeb7348f9656563c593abd9ffbb79dba1

## UX required-module debt

実体と異なる true への変更は行わず、既存gateのbaselineへ監査済み4件を追加しました。

- linux-infra-textbook2 / Profile A / quickStart
- it-infra-software-essentials-book / Profile B / troubleshootingFlow
- it-infra-software-essentials-book / Profile B / figureIndex
- IT-infra-book / Profile B / figureIndex

baseline 8、current 8、unapproved 0、stale 0を維持します。

## Debt差分

- empty summary.ja: 32 → 29
- missing lastReviewedAt: 42 → 39
- missing reviewIssue: 41 → 38
- provisional notes: 32 → 29
- required UX module debt: 4 → 8（すべて監査済みbaseline）
- reader-view leaks: 0

## 検証

- npm ci（0 vulnerabilities）
- npm run generate
- npm run verify（catalog 49、learning paths 7、catalog debt tests 11、production smoke tests 8、drift tests 7、Playwright 45）
- node scripts/validate-ux-registry.js（41 books）
- npm audit --audit-level=moderate（0 vulnerabilities）
- sourceRefs URL監査（全HTTP 200）
- built /books/ の3概要表示と運用notes非露出
- git diff --check

Closes #208
Parent: #187