### PR TITLE
feat: Proxmox / Kubernetes 4冊のcatalog監査

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1285,7 +1285,8 @@
       "prerequisites": [],
       "estimatedWeeks": null,
       "recommendedAfter": [
-        "kubernetes-cluster-ops-book"
+        "kubernetes-cluster-ops-book",
+        "podman-book"
       ],
       "languages": [
         "ja"
@@ -1310,7 +1311,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。Podman本は必要時の参照であり必須前提にせず、次読は本文で明示されたkubernetes-cluster-ops-bookとした。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。Podman本は必要時の参照であり必須前提にせず、次読は本文とあとがきで明示されたkubernetes-cluster-ops-bookとpodman-bookとした。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/README.md",

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1185,19 +1185,21 @@
         "applied-technologies"
       ],
       "levels": [
-        "intermediate",
-        "advanced"
+        "beginner",
+        "intermediate"
       ],
       "roles": [
         "infrastructure-engineer",
-        "backend-engineer"
+        "architect"
       ],
       "audiences": [
-        "中級者以上 / 特定技術スタックの実践的活用"
+        "Proxmox VEを評価し、単一ノードからクラスタまでの導入・運用を担うインフラエンジニア",
+        "小〜中規模のオンプレミス仮想化基盤を提案・構築するシステムインテグレーター",
+        "既存仮想化基盤からの移行、バックアップ、監視、障害対応をレビューする技術リーダー"
       ],
       "summary": {
-        "ja": "",
-        "en": "Explains how to build and operate virtualization environments with Proxmox VE in practical scenarios."
+        "ja": "Proxmox VE 9.1を前提に、単一ノード導入からクラスタ、ストレージ、ネットワーク、バックアップ、監視、障害対応、エンタープライズ連携までを、設計判断と安全な運用の観点で体系化した実践書です。",
+        "en": "A practical guide for infrastructure engineers evaluating or deploying Proxmox VE 9.1, covering single-node setup, clusters, storage, networking, backups, monitoring, incident response, and enterprise integration with explicit design and operational tradeoffs."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
@@ -1207,13 +1209,13 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 214,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
@@ -1223,16 +1225,23 @@
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/proxmox_book#131で、source main bc8cf4bfb6a638b7da771162a43c1de25afce820のREADME、book-config、公開トップ、導入、環境準備、運用章、図表導線を照合し、対象読者、Profile B、modulesを確定。一般的なライセンス表記は専用legal notice moduleとして扱わず、所要時間は週換算しないためestimatedWeeksはnullを維持した。根拠のある前提・次読書籍はない。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/proxmox_book/blob/bc8cf4bfb6a638b7da771162a43c1de25afce820/README.md",
+        "https://github.com/itdojp/proxmox_book/blob/bc8cf4bfb6a638b7da771162a43c1de25afce820/book-config.json",
+        "https://github.com/itdojp/proxmox_book/blob/bc8cf4bfb6a638b7da771162a43c1de25afce820/docs/index.md",
+        "https://github.com/itdojp/proxmox_book/blob/bc8cf4bfb6a638b7da771162a43c1de25afce820/docs/_data/navigation.yml",
+        "https://github.com/itdojp/proxmox_book/blob/bc8cf4bfb6a638b7da771162a43c1de25afce820/docs/introduction/index.md",
+        "https://github.com/itdojp/proxmox_book/blob/bc8cf4bfb6a638b7da771162a43c1de25afce820/docs/introduction/env-setup.md",
+        "https://github.com/itdojp/proxmox_book/blob/bc8cf4bfb6a638b7da771162a43c1de25afce820/docs/chapters/chapter-09-operations.md",
+        "https://github.com/itdojp/proxmox_book/blob/bc8cf4bfb6a638b7da771162a43c1de25afce820/docs/diagrams/part4/ch9/triage-flow.svg",
+        "https://github.com/itdojp/proxmox_book/issues/131",
+        "https://github.com/itdojp/proxmox_book/pull/132",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214#issuecomment-4950006573"
       ]
     },
     {
@@ -1257,53 +1266,68 @@
         "applied-technologies"
       ],
       "levels": [
-        "intermediate",
-        "advanced"
+        "beginner",
+        "intermediate"
       ],
       "roles": [
-        "infrastructure-engineer",
-        "backend-engineer"
+        "backend-engineer",
+        "infrastructure-engineer"
       ],
       "audiences": [
-        "中級者以上 / 特定技術スタックの実践的活用"
+        "Kubernetesへアプリケーションを載せる基礎をハンズオンで学びたい初学者",
+        "kubectl、YAML、Pod、Deployment、Service、Ingressを整理したいアプリケーション／インフラ担当者",
+        "実務チェックリストと基本的な障害切り分け手順を必要とする開発・運用担当者"
       ],
       "summary": {
-        "ja": "",
-        "en": "Introduces Kubernetes from core objects to service exposure, with hands-on operational basics."
+        "ja": "Kubernetesを学び始めるアプリケーション／インフラ担当者が、kubectl、YAML、Pod、Deployment、Service、Ingress、設定・ストレージの基礎をハンズオンで学び、実務チェックリストと障害切り分けへつなげる入門実践書です。",
+        "en": "A hands-on introductory guide for application and infrastructure engineers to learn kubectl, YAML, Pods, Deployments, Services, Ingress, configuration, and storage, then apply practical checklists and troubleshooting flows."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "kubernetes-cluster-ops-book"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 214,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
+          "figureIndex": false,
           "legalNotice": false,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "初期登録",
-        "日本語個別概要はREADME公開カタログ上で未記載。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。Podman本は必要時の参照であり必須前提にせず、次読は本文で明示されたkubernetes-cluster-ops-bookとした。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/README.md",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/book-config.json",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/book-formatter-config.json",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/docs/index.md",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/docs/_data/navigation.yml",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/docs/introduction/index.md",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/docs/appendices/appendix-a/index.md",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/docs/appendices/appendix-b/index.md",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/docs/appendices/appendix-d/index.md",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/docs/afterword/index.md",
+        "https://github.com/itdojp/kubernetes-basics-book/issues/34",
+        "https://github.com/itdojp/kubernetes-basics-book/pull/35",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214#issuecomment-4950006573"
       ]
     },
     {
@@ -1333,48 +1357,66 @@
       ],
       "roles": [
         "infrastructure-engineer",
-        "backend-engineer"
+        "sre",
+        "architect"
       ],
       "audiences": [
-        "中級者以上 / 特定技術スタックの実践的活用"
+        "Kubernetesクラスタの設計・運用を担うインフラエンジニア、SRE、プラットフォーム担当者",
+        "責任分界、HA、etcd、ネットワーク、ストレージ、認証認可、監視を体系化したい運用担当者",
+        "チェックリストとRunbookでクラスタ運用品質を標準化する技術リーダー・アーキテクト"
       ],
       "summary": {
-        "ja": "",
-        "en": "Covers Kubernetes cluster design and day-2 operations with reliability, lifecycle, and security concerns in mind."
+        "ja": "Kubernetesクラスタの設計・運用責任者が、責任分界、HA、etcd、ネットワーク、ストレージ、認証認可、監視、障害対応、アップグレード、自動化を整理し、チェックリストとRunbookで運用品質を標準化するための実践書です。",
+        "en": "A practical guide for Kubernetes cluster owners to structure responsibility boundaries, high availability, etcd, networking, storage, access control, observability, incident response, upgrades, and automation, using checklists and runbooks to standardize operations."
       },
-      "prerequisites": [],
+      "prerequisites": [
+        "kubernetes-basics-book"
+      ],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "kubernetes-proxmox-to-cloud-book"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 214,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
+          "figureIndex": false,
           "legalNotice": false,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "初期登録",
-        "日本語個別概要はREADME公開カタログ上で未記載。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-cluster-ops-book#34で、source main b1cda610e6c006589093b5cce1b5d7a6f63b6474のREADME、両config、公開トップ、導入、チェックリスト、Runbook、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。本文で案内されたkubernetes-basics-bookを前提とし、次読はポータル正本のcloud-container学習パスに基づきkubernetes-proxmox-to-cloud-bookとした。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/README.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/book-config.json",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/book-formatter-config.json",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/docs/index.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/docs/_data/navigation.yml",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/docs/introduction/index.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/docs/appendices/appendix-a/index.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/docs/appendices/appendix-b/index.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/docs/chapters/chapter11/index.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/docs/afterword/index.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/issues/34",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/pull/35",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214#issuecomment-4950006573"
       ]
     },
     {
@@ -1404,14 +1446,17 @@
       ],
       "roles": [
         "infrastructure-engineer",
-        "backend-engineer"
+        "sre",
+        "architect"
       ],
       "audiences": [
-        "中級者以上 / 特定技術スタックの実践的活用"
+        "Proxmox上の検証Kubernetesをクラウド本番へ移行するインフラエンジニア",
+        "ロードバランサー、ストレージ、認証、可観測性の環境差分を整理するSRE・運用担当者",
+        "kubeadm、Kustomize、Helm、GitOpsを使った再現可能な移行・復旧設計をレビューするアーキテクト"
       ],
       "summary": {
-        "ja": "",
-        "en": "Bridges local Proxmox-based Kubernetes experiments to cloud production architecture and operations."
+        "ja": "Proxmox上の検証Kubernetesからクラウド本番へ移行する担当者が、ロードバランサー、ストレージ、認証、可観測性の差分を整理し、kubeadm、Kustomize、Helm、GitOps、運用・復旧を再現可能な設計へ落とし込む実務ガイドです。",
+        "en": "A practical migration guide for moving Kubernetes from a Proxmox lab to cloud production, mapping load balancing, storage, identity, and observability differences into reproducible designs with kubeadm, Kustomize, Helm, GitOps, operations, and recovery."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
@@ -1421,8 +1466,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 214,
       "ux": {
         "profile": "B",
         "modules": {
@@ -1431,21 +1476,35 @@
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
-          "legalNotice": false,
+          "figureIndex": false,
+          "legalNotice": true,
           "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "初期登録",
-        "日本語個別概要はREADME公開カタログ上で未記載。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-proxmox-to-cloud-book#39で、source main d445b408e506551923bb3c1aa38d383ba9961e24のREADME、book-config、公開トップ、Quick Start、読み方、ライセンスFAQ、チェックリスト、トラブルシュート、用語集を照合し、対象読者、Profile B、modulesを確定。1〜3週間の範囲表記はcatalogの単一整数へ任意転記せずestimatedWeeksはnull。必須前提は追加せず、現行cloud-container学習パス末尾のpodman-bookは内容上の順序を再監査するitdojp/it-engineer-knowledge-architecture#216へ分離したため、根拠のある次読書籍も追加しない。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/README.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/book-config.json",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/index.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/_data/navigation.yml",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/introduction/preface.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/introduction/quickstart.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/introduction/reading-guide.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/introduction/license-faq.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/appendices/smoke-test-checklist/index.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/appendices/troubleshooting/index.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/appendices/glossary/index.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/docs/appendices/version-matrix/index.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/issues/39",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/pull/40",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214#issuecomment-4950006573"
       ]
     },
     {

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -423,15 +423,15 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
+        "figureIndex": false,
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "初期登録"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。Podman本は必要時の参照であり必須前提にせず、次読は本文で明示されたkubernetes-cluster-ops-bookとした。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
     },
     "kubernetes-cluster-ops-book": {
       "repo": "itdojp/kubernetes-cluster-ops-book",
@@ -439,15 +439,15 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
+        "figureIndex": false,
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "初期登録"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-cluster-ops-book#34で、source main b1cda610e6c006589093b5cce1b5d7a6f63b6474のREADME、両config、公開トップ、導入、チェックリスト、Runbook、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。本文で案内されたkubernetes-basics-bookを前提とし、次読はポータル正本のcloud-container学習パスに基づきkubernetes-proxmox-to-cloud-bookとした。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
     },
     "kubernetes-proxmox-to-cloud-book": {
       "repo": "itdojp/kubernetes-proxmox-to-cloud-book",
@@ -459,11 +459,11 @@
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
+        "figureIndex": false,
+        "legalNotice": true,
         "glossary": true
       },
-      "notes": "初期登録"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-proxmox-to-cloud-book#39で、source main d445b408e506551923bb3c1aa38d383ba9961e24のREADME、book-config、公開トップ、Quick Start、読み方、ライセンスFAQ、チェックリスト、トラブルシュート、用語集を照合し、対象読者、Profile B、modulesを確定。1〜3週間の範囲表記はcatalogの単一整数へ任意転記せずestimatedWeeksはnull。必須前提は追加せず、現行cloud-container学習パス末尾のpodman-bookは内容上の順序を再監査するitdojp/it-engineer-knowledge-architecture#216へ分離したため、根拠のある次読書籍も追加しない。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
     },
     "linux-infra-textbook2": {
       "repo": "itdojp/linux-infra-textbook2",
@@ -567,7 +567,7 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
@@ -575,7 +575,7 @@
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/proxmox_book#131で、source main bc8cf4bfb6a638b7da771162a43c1de25afce820のREADME、book-config、公開トップ、導入、環境準備、運用章、図表導線を照合し、対象読者、Profile B、modulesを確定。一般的なライセンス表記は専用legal notice moduleとして扱わず、所要時間は週換算しないためestimatedWeeksはnullを維持した。根拠のある前提・次読書籍はない。"
     },
     "security-privacy-literacy-book": {
       "repo": "itdojp/security-privacy-literacy-book",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -431,7 +431,7 @@
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。Podman本は必要時の参照であり必須前提にせず、次読は本文で明示されたkubernetes-cluster-ops-bookとした。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。Podman本は必要時の参照であり必須前提にせず、次読は本文とあとがきで明示されたkubernetes-cluster-ops-bookとpodman-bookとした。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
     },
     "kubernetes-cluster-ops-book": {
       "repo": "itdojp/kubernetes-cluster-ops-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -10,7 +10,7 @@
   },
   "debt": {
     "emptySummaryJa": {
-      "count": 25,
+      "count": 21,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -27,13 +27,9 @@
         "formal-methods-book",
         "github-guide-for-beginners-book",
         "github-workflow-book",
-        "kubernetes-basics-book",
-        "kubernetes-cluster-ops-book",
-        "kubernetes-proxmox-to-cloud-book",
         "negotiation-for-engineers-book",
         "podman-book",
         "practical-auth-book",
-        "proxmox_book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
         "theoretical-computer-science-textbook"
@@ -98,7 +94,7 @@
       ]
     },
     "missingLastReviewedAt": {
-      "count": 35,
+      "count": 31,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -122,15 +118,11 @@
         "github-workflow-book",
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
-        "kubernetes-basics-book",
-        "kubernetes-cluster-ops-book",
-        "kubernetes-proxmox-to-cloud-book",
         "negotiation-for-engineers-book",
         "next-generation-infrastructure-guide",
         "podman-book",
         "practical-auth-book",
         "practical-security-infrastructure-guide",
-        "proxmox_book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
         "theoretical-computer-science-prerequisites-book",
@@ -138,7 +130,7 @@
       ]
     },
     "missingReviewIssue": {
-      "count": 34,
+      "count": 30,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -161,15 +153,11 @@
         "github-workflow-book",
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
-        "kubernetes-basics-book",
-        "kubernetes-cluster-ops-book",
-        "kubernetes-proxmox-to-cloud-book",
         "negotiation-for-engineers-book",
         "next-generation-infrastructure-guide",
         "podman-book",
         "practical-auth-book",
         "practical-security-infrastructure-guide",
-        "proxmox_book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
         "theoretical-computer-science-prerequisites-book",
@@ -177,7 +165,7 @@
       ]
     },
     "provisionalNotes": {
-      "count": 25,
+      "count": 21,
       "books": [
         {
           "id": "BioinformaticsGuide-book",
@@ -299,24 +287,6 @@
           ]
         },
         {
-          "id": "kubernetes-basics-book",
-          "notes": [
-            "日本語個別概要はREADME公開カタログ上で未記載。"
-          ]
-        },
-        {
-          "id": "kubernetes-cluster-ops-book",
-          "notes": [
-            "日本語個別概要はREADME公開カタログ上で未記載。"
-          ]
-        },
-        {
-          "id": "kubernetes-proxmox-to-cloud-book",
-          "notes": [
-            "日本語個別概要はREADME公開カタログ上で未記載。"
-          ]
-        },
-        {
           "id": "negotiation-for-engineers-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
@@ -334,14 +304,6 @@
         },
         {
           "id": "practical-auth-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
-          "id": "proxmox_book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
             "日本語個別概要はREADME公開カタログ上で未記載。",
@@ -427,7 +389,7 @@
       ]
     },
     "uxEvidenceCandidates": {
-      "count": 23,
+      "count": 22,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -448,15 +410,14 @@
         "negotiation-for-engineers-book",
         "podman-book",
         "practical-auth-book",
-        "proxmox_book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
         "theoretical-computer-science-textbook"
       ]
     },
     "missingRequiredUxModules": {
-      "count": 13,
-      "bookCount": 10,
+      "count": 16,
+      "bookCount": 13,
       "books": [
         {
           "id": "IT-infra-book",
@@ -555,6 +516,42 @@
           ]
         },
         {
+          "id": "kubernetes-basics-book",
+          "profile": "B",
+          "missingModules": [
+            {
+              "module": "figureIndex",
+              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 214,
+              "trackingIssue": 215
+            }
+          ]
+        },
+        {
+          "id": "kubernetes-cluster-ops-book",
+          "profile": "B",
+          "missingModules": [
+            {
+              "module": "figureIndex",
+              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 214,
+              "trackingIssue": 215
+            }
+          ]
+        },
+        {
+          "id": "kubernetes-proxmox-to-cloud-book",
+          "profile": "B",
+          "missingModules": [
+            {
+              "module": "figureIndex",
+              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 214,
+              "trackingIssue": 215
+            }
+          ]
+        },
+        {
           "id": "linux-infra-textbook2",
           "profile": "A",
           "missingModules": [
@@ -605,8 +602,8 @@
   },
   "gates": {
     "requiredUxModuleDebt": {
-      "baselineCount": 13,
-      "currentCount": 13,
+      "baselineCount": 16,
+      "currentCount": 16,
       "unapprovedCount": 0,
       "unapproved": [],
       "staleBaselineCount": 0,

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -74,6 +74,30 @@
       "trackingIssue": 210
     },
     {
+      "bookId": "kubernetes-basics-book",
+      "profile": "B",
+      "module": "figureIndex",
+      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 214,
+      "trackingIssue": 215
+    },
+    {
+      "bookId": "kubernetes-cluster-ops-book",
+      "profile": "B",
+      "module": "figureIndex",
+      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 214,
+      "trackingIssue": 215
+    },
+    {
+      "bookId": "kubernetes-proxmox-to-cloud-book",
+      "profile": "B",
+      "module": "figureIndex",
+      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 214,
+      "trackingIssue": 215
+    },
+    {
       "bookId": "linux-infra-textbook2",
       "profile": "A",
       "module": "quickStart",


### PR DESCRIPTION
## 概要

Issue #214のQuality Sprintとして、displayOrder 15〜18の4冊を固定main SHAと公開Pagesで監査し、catalog metadata、UX module、監査証跡、required UX module debt baselineを更新します。

対象:
- `proxmox_book`
- `kubernetes-basics-book`
- `kubernetes-cluster-ops-book`
- `kubernetes-proxmox-to-cloud-book`

Related to #214

## Source側の先行補正

- itdojp/proxmox_book#132 → `bc8cf4bfb6a638b7da771162a43c1de25afce820`
- itdojp/kubernetes-basics-book#35 → `8e02d0298fc9a9bb960b0bb1acec5d5fea259522`
- itdojp/kubernetes-cluster-ops-book#35 → `b1cda610e6c006589093b5cce1b5d7a6f63b6474`
- itdojp/kubernetes-proxmox-to-cloud-book#40 → `d445b408e506551923bb3c1aa38d383ba9961e24`

4 PRともreview completeness status=ok、CI green、main Book QA / Pages success、公開Pages HTTP 200を確認済みです。

## 変更内容

- 4冊の日英概要、対象読者、levels、rolesを実内容に合わせて確定
- 週数は単一整数の根拠がないため全冊`estimatedWeeks=null`を維持
- Kubernetes基礎→クラスタ運用の前提・次読関係を本文根拠で設定
- Profile B / 8 moduleを公開実体へ整合
- 4冊のreview date / Issue、具体的notes、固定SHA sourceRefsを記録
- Kubernetes 3冊の未実装`figureIndex`をbaselineへ追加
  - evidence: #214
  - open tracking: #215
- 独立レビューで見つかったcloud-container末尾のPodman配置の違和感は、このPRへ順序変更を混在させず #216 へ分離
  - `kubernetes-proxmox-to-cloud-book.recommendedAfter`へは転記しない
- 既存UX debt #210 / #212は変更しない

監査根拠: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214#issuecomment-4950006573

## Debt差分

- empty summary.ja: 25 → 21
- missing lastReviewedAt: 35 → 31
- missing reviewIssue: 34 → 30
- provisional notes: 25 → 21
- missing estimatedWeeks: 41 → 41
- required UX module debt: 13 → 16
- required UX debt books: 10 → 13
- baseline/current: 16 / 16
- unapproved/stale: 0 / 0
- reader-view leaks: 0

## 検証

- `npm ci`（0 vulnerabilities）
- `npm run generate`
- `npm run verify`
  - catalog 49 records / 7 paths
  - catalog debt tests 11/11
  - production smoke tests 8/8
  - Pages drift tests 7/7
  - Playwright 45/45（desktop/tablet/mobile、axe違反なし）
- `node scripts/validate-ux-registry.js`（41 books）
- `npm audit --audit-level=moderate`（0 vulnerabilities）
- 対象4冊のsourceRefs 60 URL: HTTP 200
- `git diff --check`

## レビュー上の判断

独立reviewerのMedium指摘「発展的なProxmox-to-Cloud本の次に基礎的なPodman本を置くのは不自然」は採用し、個別`recommendedAfter`を空に戻して #216 へ分離しました。

`lastReviewedAt=2026-07-12`は、source側必要修正のmerge後CI / Pages確認を同日完了しており、このPRも同日中にmain・production確認まで完了させる前提で維持します。日付を越える場合はmerge前に更新します。
