### PR TITLE
feat: audit theoretical CS catalog tranche

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1798,52 +1798,69 @@
         "computer-science-theory"
       ],
       "levels": [
-        "intermediate",
-        "advanced"
+        "beginner",
+        "intermediate"
       ],
       "roles": [
         "software-engineer",
         "architect"
       ],
       "audiences": [
-        "中級者以上 / 理論的バックグラウンドの深化"
+        "理論計算機科学を学びたいが、数学記法・証明・離散数学に不安がある読者",
+        "実務経験はあるが、集合・論理・計算量・形式言語・確率・数論を体系的に補強したいソフトウェアエンジニア",
+        "『理論計算機科学教科書』へ入る前に前提診断と演習で準備したい読者",
+        "研修・輪読会で理論計算機科学の前処理教材を使いたい教員・研修担当者"
       ],
       "summary": {
-        "ja": "集合・論理・関数・関係・証明技法・漸近記法・擬似コード・グラフ・組合せ・データ構造・形式言語・確率・数論・線形代数・並行モデルを、理論計算機科学教科書に進むための前提として整理するブリッジ教材。",
-        "en": "A Japanese bridge textbook for readers who need prerequisites before studying theoretical computer science: sets, logic, proofs, asymptotic notation, graphs, counting, data structures, formal languages, probability, number theory, linear algebra, and concurrency models."
+        "ja": "理論計算機科学へ進む読者が、集合・論理、証明、漸近記法、グラフ、形式言語、確率、数論、線形代数、並行モデルを前提診断と演習で補強し、本体教科書を定義・定理・擬似コードで止まらず読める状態を目指すブリッジ教材です。",
+        "en": "A Japanese bridge textbook for readers preparing for theoretical computer science, using prerequisite diagnostics and exercises to strengthen sets, logic, proofs, asymptotic notation, graphs, formal languages, probability, number theory, linear algebra, and concurrency models."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "theoretical-computer-science-textbook"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 222,
       "ux": {
         "profile": "C",
         "modules": {
-          "quickStart": true,
+          "quickStart": false,
           "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": false,
-          "conceptMap": true,
+          "conceptMap": false,
           "figureIndex": true,
-          "legalNotice": true,
+          "legalNotice": false,
           "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "理論計算機科学教科書の前提補強ブリッジ教材"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222とsource修正itdojp/theoretical-computer-science-prerequisites-book#5 / #7、PR #6 / #8で、source main a6b193c0546630fa580998b04ad90ca067194a80のREADME、book-config、公開トップ、学習パス、前提診断、本体対応表、索引を照合し、対象読者、初級〜中級、Profile C、modulesを確定。前提教材から本体教科書への明示導線に基づきrecommendedAfterを設定した。Core 2〜4週、Standard 6〜8週、Extended 10〜12週は複数ルートで単一整数を代表値化できないためestimatedWeeksはnull。専用concept mapは未実装のためitdojp/it-engineer-knowledge-architecture#223で分離追跡し、逆引きconcept indexを代用してtrueにはしない。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/README.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/book-config.json",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/index.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/_data/navigation.yml",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/learning-path.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/appendix/mapping-to-main-textbook.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/reference/concept-index.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/reference/glossary.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/reference/symbol-index.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/issues/5",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/pull/6",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/issues/7",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/pull/8",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/222",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/223"
       ]
     },
     {
@@ -1876,26 +1893,25 @@
         "architect"
       ],
       "audiences": [
-        "中級者以上 / 理論的バックグラウンドの深化"
+        "情報系学部3〜4年生、または大学院初年度で、離散数学と基本的なプログラミング経験がある読者",
+        "計算可能性・複雑性・形式言語・情報理論を体系で学び直したいソフトウェアエンジニア"
       ],
       "summary": {
-        "ja": "",
-        "en": "Builds a foundation in algorithms, automata, computability, and complexity theory."
+        "ja": "離散数学と基本的なプログラミング経験を持つ学部上級生・大学院初年度・ソフトウェアエンジニアに向けて、集合・論理から計算可能性・複雑性・情報理論・暗号・並行計算までを日本語で体系的に学べる理論計算機科学の教科書です。",
+        "en": "A Japanese theoretical computer science textbook for advanced undergraduates, early graduate students, and software engineers with discrete mathematics and basic programming experience, covering sets and logic, formal languages, computability, complexity, information theory, cryptography, and concurrency."
       },
       "prerequisites": [
         "theoretical-computer-science-prerequisites-book"
       ],
       "estimatedWeeks": null,
-      "recommendedAfter": [
-        "theoretical-computer-science-prerequisites-book"
-      ],
+      "recommendedAfter": [],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 222,
       "ux": {
         "profile": "C",
         "modules": {
@@ -1910,16 +1926,30 @@
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222で、source main 898c224bd4eb48268147f165a161506782ab2b10のREADME、book-config、公開トップ、目的、学習ガイド、前提知識、概念マップ、図表索引、用語集を照合し、対象読者、中級〜上級、Profile C、modulesを確定。前提補強教材をprerequisitesに維持し、同教材へ戻す循環的なrecommendedAfterは削除した。短時間の読書目安と学期・月単位の学習計画が併存するためestimatedWeeksはnullとし、期間driftはitdojp/theoretical-computer-science-textbook#394で追跡する。metadataは#393、本文正確性P0は#397 / #398 / #399 / #401 / #402、Jekyll/Faraday warningは#403で分離追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/README.md",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/book-config.json",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/docs/index.md",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/docs/_data/navigation.yml",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/docs/introduction/purpose.md",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/docs/introduction/learning-guide.md",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/docs/introduction/prerequisites.md",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/docs/appendices/d.md",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/docs/appendices/h.md",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/docs/appendices/i.md",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/issues/393",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/issues/394",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/issues/397",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/issues/398",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/issues/399",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/issues/401",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/issues/402",
+        "https://github.com/itdojp/theoretical-computer-science-textbook/issues/403",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/222"
       ]
     },
     {
@@ -1952,11 +1982,13 @@
         "architect"
       ],
       "audiences": [
-        "中級者以上 / 理論的バックグラウンドの深化"
+        "AIを用いた実装・テスト生成を運用している、または導入したい開発者・テックリード",
+        "仕様追加・境界破壊・検証漏れを、成果物とプロセスで抑止したい読者",
+        "GitHubのIssue・PRとCIで、レビュー可能な差分として設計を運用したい読者"
       ],
       "summary": {
-        "ja": "",
-        "en": "Japanese book focused on category-theoretic design for the AI agent era. It stands alongside the separate English book Compositional Software Design for Agentic Systems rather than serving as an older edition or a direct translation."
+        "ja": "AI実装・テスト生成を運用する開発者やテックリードが、圏論の対象・射・図式・関手・自然変換・普遍性・モナドを、Context Pack、設計成果物、検証条件、CIへ接続し、AIへの委任をレビュー可能なソフトウェア設計として運用するための実務書です。",
+        "en": "A Japanese practical guide for developers and technical leads using AI-assisted implementation and testing, connecting category-theoretic objects, morphisms, diagrams, functors, natural transformations, universal constructions, and monads to Context Packs, verifiable design artifacts, review, and CI."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
@@ -1968,8 +2000,8 @@
         "composable-software-design-book"
       ],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 222,
       "ux": {
         "profile": "C",
         "modules": {
@@ -1986,15 +2018,19 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "Profile C の暫定割当。付録Dは図版・レビュー前の最小確認項目・症状別再参照の入口として扱う。raw サンプルは本文より先に更新される場合があるため要確認。",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-        "独立英語書籍 composable-software-design-book と関連。単純翻訳・旧新版関係ではない。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222で、source main e1d0df204ecf49322b6d932ffbf5e23daa629a29のREADME、book-config、公開トップ、navigation、用語集、テンプレート、付録Dのdesk reference、参考文献を照合し、対象読者、中級〜上級、Profile C、modulesを確定。通読2〜4時間と演習1〜2日は週単位の標準計画ではないためestimatedWeeksはnull。composable-software-design-bookとはAI時代の合成的設計を扱う独立した関連英語書籍であり、翻訳・旧新版関係ではない。付録Dは図版、レビュー前の最小確認項目、症状別再参照の入口を提供する。package-lock / Gemfile.lockの欠落とJekyll/Faraday warningはitdojp/categorical-software-design-book#141で分離追跡する。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/categorical-software-design-book/blob/e1d0df204ecf49322b6d932ffbf5e23daa629a29/README.md",
+        "https://github.com/itdojp/categorical-software-design-book/blob/e1d0df204ecf49322b6d932ffbf5e23daa629a29/book-config.json",
+        "https://github.com/itdojp/categorical-software-design-book/blob/e1d0df204ecf49322b6d932ffbf5e23daa629a29/index.md",
+        "https://github.com/itdojp/categorical-software-design-book/blob/e1d0df204ecf49322b6d932ffbf5e23daa629a29/_data/navigation.yml",
+        "https://github.com/itdojp/categorical-software-design-book/blob/e1d0df204ecf49322b6d932ffbf5e23daa629a29/GLOSSARY.md",
+        "https://github.com/itdojp/categorical-software-design-book/blob/e1d0df204ecf49322b6d932ffbf5e23daa629a29/appendices/templates/index.md",
+        "https://github.com/itdojp/categorical-software-design-book/blob/e1d0df204ecf49322b6d932ffbf5e23daa629a29/appendices/desk-reference/index.md",
+        "https://github.com/itdojp/categorical-software-design-book/blob/e1d0df204ecf49322b6d932ffbf5e23daa629a29/appendices/references/index.md",
+        "https://github.com/itdojp/categorical-software-design-book/issues/141",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/222"
       ]
     },
     {

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1909,8 +1909,8 @@
         "ja"
       ],
       "relatedEditions": [],
-      "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
+      "reviewStatus": "review-needed",
+      "lastReviewedAt": null,
       "reviewIssue": 222,
       "ux": {
         "profile": "C",
@@ -1928,7 +1928,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222で、source main 898c224bd4eb48268147f165a161506782ab2b10のREADME、book-config、公開トップ、目的、学習ガイド、前提知識、概念マップ、図表索引、用語集を照合し、対象読者、中級〜上級、Profile C、modulesを確定。前提補強教材をprerequisitesに維持し、同教材へ戻す循環的なrecommendedAfterは削除した。短時間の読書目安と学期・月単位の学習計画が併存するためestimatedWeeksはnullとし、期間driftはitdojp/theoretical-computer-science-textbook#394で追跡する。metadataは#393、本文正確性P0は#397 / #398 / #399 / #401 / #402、Jekyll/Faraday warningは#403で分離追跡する。"
+        "2026-07-12のmetadata・公開表示監査itdojp/it-engineer-knowledge-architecture#222で、source main 898c224bd4eb48268147f165a161506782ab2b10のREADME、book-config、公開トップ、目的、学習ガイド、前提知識、概念マップ、図表索引、用語集を照合し、対象読者、中級〜上級、Profile C、modulesを確定。前提補強教材をprerequisitesに維持し、同教材へ戻す循環的なrecommendedAfterは削除した。短時間の読書目安と学期・月単位の学習計画が併存するためestimatedWeeksはnullとし、期間driftはitdojp/theoretical-computer-science-textbook#394で追跡する。metadataは#393、本文正確性P0は#397 / #398 / #399 / #401 / #402、Jekyll/Faraday warningは#403で分離追跡する。P0本文修正とmerge後確認が未完了のためreviewStatusはreview-needed、lastReviewedAtはnullを維持し、本監査の範囲と判断はreviewIssue #222で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/theoretical-computer-science-textbook/blob/898c224bd4eb48268147f165a161506782ab2b10/README.md",

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1816,7 +1816,7 @@
         "en": "A Japanese bridge textbook for readers preparing for theoretical computer science, using prerequisite diagnostics and exercises to strengthen sets, logic, proofs, asymptotic notation, graphs, formal languages, probability, number theory, linear algebra, and concurrency models."
       },
       "prerequisites": [],
-      "estimatedWeeks": null,
+      "estimatedWeeks": "6-8週間",
       "recommendedAfter": [
         "theoretical-computer-science-textbook"
       ],
@@ -1843,7 +1843,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222とsource修正itdojp/theoretical-computer-science-prerequisites-book#5 / #7、PR #6 / #8で、source main a6b193c0546630fa580998b04ad90ca067194a80のREADME、book-config、公開トップ、学習パス、前提診断、本体対応表、索引を照合し、対象読者、初級〜中級、Profile C、modulesを確定。前提教材から本体教科書への明示導線に基づきrecommendedAfterを設定した。Core 2〜4週、Standard 6〜8週、Extended 10〜12週は複数ルートで単一整数を代表値化できないためestimatedWeeksはnull。専用concept mapは未実装のためitdojp/it-engineer-knowledge-architecture#223で分離追跡し、逆引きconcept indexを代用してtrueにはしない。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222とsource修正itdojp/theoretical-computer-science-prerequisites-book#5 / #7、PR #6 / #8で、source main a6b193c0546630fa580998b04ad90ca067194a80のREADME、book-config、公開トップ、学習パス、前提診断、本体対応表、索引を照合し、対象読者、初級〜中級、Profile C、modulesを確定。前提教材から本体教科書への明示導線に基づきrecommendedAfterを設定した。本文が標準ルートをCoreとStandard中心の6〜8週間と明示しているためestimatedWeeksを6-8週間とし、最短2〜4週と拡張10〜12週は代替ルートとしてnotesに保持する。専用concept mapは未実装のためitdojp/it-engineer-knowledge-architecture#223で分離追跡し、逆引きconcept indexを代用してtrueにはしない。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/README.md",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -639,7 +639,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222とsource修正itdojp/theoretical-computer-science-prerequisites-book#5 / #7、PR #6 / #8で、source main a6b193c0546630fa580998b04ad90ca067194a80のREADME、book-config、公開トップ、学習パス、前提診断、本体対応表、索引を照合し、対象読者、初級〜中級、Profile C、modulesを確定。前提教材から本体教科書への明示導線に基づきrecommendedAfterを設定した。Core 2〜4週、Standard 6〜8週、Extended 10〜12週は複数ルートで単一整数を代表値化できないためestimatedWeeksはnull。専用concept mapは未実装のためitdojp/it-engineer-knowledge-architecture#223で分離追跡し、逆引きconcept indexを代用してtrueにはしない。"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222とsource修正itdojp/theoretical-computer-science-prerequisites-book#5 / #7、PR #6 / #8で、source main a6b193c0546630fa580998b04ad90ca067194a80のREADME、book-config、公開トップ、学習パス、前提診断、本体対応表、索引を照合し、対象読者、初級〜中級、Profile C、modulesを確定。前提教材から本体教科書への明示導線に基づきrecommendedAfterを設定した。本文が標準ルートをCoreとStandard中心の6〜8週間と明示しているためestimatedWeeksを6-8週間とし、最短2〜4週と拡張10〜12週は代替ルートとしてnotesに保持する。専用concept mapは未実装のためitdojp/it-engineer-knowledge-architecture#223で分離追跡し、逆引きconcept indexを代用してtrueにはしない。"
     },
     "theoretical-computer-science-textbook": {
       "repo": "itdojp/theoretical-computer-science-textbook",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -127,7 +127,7 @@
         "legalNotice": true,
         "glossary": true
       },
-      "notes": "Profile C の暫定割当。付録Dは図版・レビュー前の最小確認項目・症状別再参照の入口として扱う。raw サンプルは本文より先に更新される場合があるため要確認。 / 独立英語書籍 composable-software-design-book と関連。単純翻訳・旧新版関係ではない。"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222で、source main e1d0df204ecf49322b6d932ffbf5e23daa629a29のREADME、book-config、公開トップ、navigation、用語集、テンプレート、付録Dのdesk reference、参考文献を照合し、対象読者、中級〜上級、Profile C、modulesを確定。通読2〜4時間と演習1〜2日は週単位の標準計画ではないためestimatedWeeksはnull。composable-software-design-bookとはAI時代の合成的設計を扱う独立した関連英語書籍であり、翻訳・旧新版関係ではない。付録Dは図版、レビュー前の最小確認項目、症状別再参照の入口を提供する。package-lock / Gemfile.lockの欠落とJekyll/Faraday warningはitdojp/categorical-software-design-book#141で分離追跡する。"
     },
     "cloud-infra-book": {
       "repo": "itdojp/cloud-infra-book",
@@ -630,16 +630,16 @@
       "pages": "https://itdojp.github.io/theoretical-computer-science-prerequisites-book/",
       "profile": "C",
       "modules": {
-        "quickStart": true,
+        "quickStart": false,
         "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": false,
-        "conceptMap": true,
+        "conceptMap": false,
         "figureIndex": true,
-        "legalNotice": true,
+        "legalNotice": false,
         "glossary": true
       },
-      "notes": "理論計算機科学教科書の前提補強ブリッジ教材"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222とsource修正itdojp/theoretical-computer-science-prerequisites-book#5 / #7、PR #6 / #8で、source main a6b193c0546630fa580998b04ad90ca067194a80のREADME、book-config、公開トップ、学習パス、前提診断、本体対応表、索引を照合し、対象読者、初級〜中級、Profile C、modulesを確定。前提教材から本体教科書への明示導線に基づきrecommendedAfterを設定した。Core 2〜4週、Standard 6〜8週、Extended 10〜12週は複数ルートで単一整数を代表値化できないためestimatedWeeksはnull。専用concept mapは未実装のためitdojp/it-engineer-knowledge-architecture#223で分離追跡し、逆引きconcept indexを代用してtrueにはしない。"
     },
     "theoretical-computer-science-textbook": {
       "repo": "itdojp/theoretical-computer-science-textbook",
@@ -655,7 +655,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222で、source main 898c224bd4eb48268147f165a161506782ab2b10のREADME、book-config、公開トップ、目的、学習ガイド、前提知識、概念マップ、図表索引、用語集を照合し、対象読者、中級〜上級、Profile C、modulesを確定。前提補強教材をprerequisitesに維持し、同教材へ戻す循環的なrecommendedAfterは削除した。短時間の読書目安と学期・月単位の学習計画が併存するためestimatedWeeksはnullとし、期間driftはitdojp/theoretical-computer-science-textbook#394で追跡する。metadataは#393、本文正確性P0は#397 / #398 / #399 / #401 / #402、Jekyll/Faraday warningは#403で分離追跡する。"
     },
     "wsl2-linux-essentials-book": {
       "repo": "itdojp/wsl2-linux-essentials-book",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -655,7 +655,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222で、source main 898c224bd4eb48268147f165a161506782ab2b10のREADME、book-config、公開トップ、目的、学習ガイド、前提知識、概念マップ、図表索引、用語集を照合し、対象読者、中級〜上級、Profile C、modulesを確定。前提補強教材をprerequisitesに維持し、同教材へ戻す循環的なrecommendedAfterは削除した。短時間の読書目安と学期・月単位の学習計画が併存するためestimatedWeeksはnullとし、期間driftはitdojp/theoretical-computer-science-textbook#394で追跡する。metadataは#393、本文正確性P0は#397 / #398 / #399 / #401 / #402、Jekyll/Faraday warningは#403で分離追跡する。"
+      "notes": "2026-07-12のmetadata・公開表示監査itdojp/it-engineer-knowledge-architecture#222で、source main 898c224bd4eb48268147f165a161506782ab2b10のREADME、book-config、公開トップ、目的、学習ガイド、前提知識、概念マップ、図表索引、用語集を照合し、対象読者、中級〜上級、Profile C、modulesを確定。前提補強教材をprerequisitesに維持し、同教材へ戻す循環的なrecommendedAfterは削除した。短時間の読書目安と学期・月単位の学習計画が併存するためestimatedWeeksはnullとし、期間driftはitdojp/theoretical-computer-science-textbook#394で追跡する。metadataは#393、本文正確性P0は#397 / #398 / #399 / #401 / #402、Jekyll/Faraday warningは#403で分離追跡する。P0本文修正とmerge後確認が未完了のためreviewStatusはreview-needed、lastReviewedAtはnullを維持し、本監査の範囲と判断はreviewIssue #222で追跡する。"
     },
     "wsl2-linux-essentials-book": {
       "repo": "itdojp/wsl2-linux-essentials-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -43,7 +43,7 @@
       ]
     },
     "missingEstimatedWeeks": {
-      "count": 41,
+      "count": 40,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -83,7 +83,6 @@
         "security-privacy-literacy-book",
         "small-webapp-software-design-book",
         "supabase-architecture-patterns-book",
-        "theoretical-computer-science-prerequisites-book",
         "theoretical-computer-science-textbook",
         "wsl2-linux-essentials-book"
       ]

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -10,7 +10,7 @@
   },
   "debt": {
     "emptySummaryJa": {
-      "count": 18,
+      "count": 16,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -20,7 +20,6 @@
         "ai-communication-book",
         "ai-era-engineers-mind-book",
         "ai-testing-strategy-book",
-        "categorical-software-design-book",
         "computational-physicalism-book",
         "cs-visionaries-book",
         "ethereum-learning-bootcamp",
@@ -28,8 +27,7 @@
         "github-guide-for-beginners-book",
         "github-workflow-book",
         "negotiation-for-engineers-book",
-        "small-webapp-software-design-book",
-        "theoretical-computer-science-textbook"
+        "small-webapp-software-design-book"
       ]
     },
     "emptySummaryEn": {
@@ -91,7 +89,7 @@
       ]
     },
     "missingLastReviewedAt": {
-      "count": 28,
+      "count": 25,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -102,7 +100,6 @@
         "ai-communication-book",
         "ai-era-engineers-mind-book",
         "ai-testing-strategy-book",
-        "categorical-software-design-book",
         "compliance-infrastructure-guide",
         "composable-software-design-book",
         "computational-physicalism-book",
@@ -118,13 +115,11 @@
         "negotiation-for-engineers-book",
         "next-generation-infrastructure-guide",
         "practical-security-infrastructure-guide",
-        "small-webapp-software-design-book",
-        "theoretical-computer-science-prerequisites-book",
-        "theoretical-computer-science-textbook"
+        "small-webapp-software-design-book"
       ]
     },
     "missingReviewIssue": {
-      "count": 27,
+      "count": 24,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -135,7 +130,6 @@
         "ai-communication-book",
         "ai-era-engineers-mind-book",
         "ai-testing-strategy-book",
-        "categorical-software-design-book",
         "compliance-infrastructure-guide",
         "computational-physicalism-book",
         "cs-visionaries-book",
@@ -150,13 +144,11 @@
         "negotiation-for-engineers-book",
         "next-generation-infrastructure-guide",
         "practical-security-infrastructure-guide",
-        "small-webapp-software-design-book",
-        "theoretical-computer-science-prerequisites-book",
-        "theoretical-computer-science-textbook"
+        "small-webapp-software-design-book"
       ]
     },
     "provisionalNotes": {
-      "count": 18,
+      "count": 16,
       "books": [
         {
           "id": "BioinformaticsGuide-book",
@@ -223,14 +215,6 @@
           ]
         },
         {
-          "id": "categorical-software-design-book",
-          "notes": [
-            "Profile C の暫定割当。付録Dは図版・レビュー前の最小確認項目・症状別再参照の入口として扱う。raw サンプルは本文より先に更新される場合があるため要確認。",
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。"
-          ]
-        },
-        {
           "id": "computational-physicalism-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
@@ -292,14 +276,6 @@
             "日本語個別概要はREADME公開カタログ上で未記載。",
             "暫定割当（要確認）"
           ]
-        },
-        {
-          "id": "theoretical-computer-science-textbook",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
         }
       ]
     },
@@ -356,7 +332,7 @@
       ]
     },
     "uxEvidenceCandidates": {
-      "count": 19,
+      "count": 17,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -366,7 +342,6 @@
         "ai-communication-book",
         "ai-era-engineers-mind-book",
         "ai-testing-strategy-book",
-        "categorical-software-design-book",
         "composable-software-design-book",
         "computational-physicalism-book",
         "cs-visionaries-book",
@@ -375,13 +350,12 @@
         "github-guide-for-beginners-book",
         "github-workflow-book",
         "negotiation-for-engineers-book",
-        "small-webapp-software-design-book",
-        "theoretical-computer-science-textbook"
+        "small-webapp-software-design-book"
       ]
     },
     "missingRequiredUxModules": {
-      "count": 19,
-      "bookCount": 16,
+      "count": 20,
+      "bookCount": 17,
       "books": [
         {
           "id": "IT-infra-book",
@@ -592,6 +566,18 @@
               "trackingIssue": 220
             }
           ]
+        },
+        {
+          "id": "theoretical-computer-science-prerequisites-book",
+          "profile": "C",
+          "missingModules": [
+            {
+              "module": "conceptMap",
+              "reason": "実ファイルと公開Pages監査で専用の概念マップが未実装であることを確認済み。概念別逆引きは詰まり方から参照先を探す索引であり、概念・章間依存を俯瞰するmapとして代用せず、根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 222,
+              "trackingIssue": 223
+            }
+          ]
         }
       ]
     },
@@ -602,8 +588,8 @@
   },
   "gates": {
     "requiredUxModuleDebt": {
-      "baselineCount": 19,
-      "currentCount": 19,
+      "baselineCount": 20,
+      "currentCount": 20,
       "unapprovedCount": 0,
       "unapproved": [],
       "staleBaselineCount": 0,

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -88,7 +88,7 @@
       ]
     },
     "missingLastReviewedAt": {
-      "count": 25,
+      "count": 26,
       "bookIds": [
         "BioinformaticsGuide-book",
         "GitHub-AgentOps-book",
@@ -114,7 +114,8 @@
         "negotiation-for-engineers-book",
         "next-generation-infrastructure-guide",
         "practical-security-infrastructure-guide",
-        "small-webapp-software-design-book"
+        "small-webapp-software-design-book",
+        "theoretical-computer-science-textbook"
       ]
     },
     "missingReviewIssue": {

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -152,6 +152,14 @@
       "reason": "実ファイルと公開Pages監査で専用の概念マップが未実装であることを確認済み。パターン選定ガイドや個別図版を概念マップとして代用せず、根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 219,
       "trackingIssue": 220
+    },
+    {
+      "bookId": "theoretical-computer-science-prerequisites-book",
+      "profile": "C",
+      "module": "conceptMap",
+      "reason": "実ファイルと公開Pages監査で専用の概念マップが未実装であることを確認済み。概念別逆引きは詰まり方から参照先を探す索引であり、概念・章間依存を俯瞰するmapとして代用せず、根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 222,
+      "trackingIssue": 223
     }
   ]
 }


### PR DESCRIPTION
## Summary

- audit the displayOrder 22–24 theoretical-computer-science catalog tranche
- replace provisional summaries, audiences, review evidence, notes, and source references with final fixed-SHA evidence
- establish the non-cyclic prerequisites-book → textbook learning direction
- align prerequisites-book UX flags to the source fix and baseline the missing Profile C concept map under #223
- regenerate the public book registry and catalog debt report

## Source evidence

- prerequisites book final main: a6b193c0546630fa580998b04ad90ca067194a80 (#5 / PR #6, #7 / PR #8)
- TCS textbook final main: 898c224bd4eb48268147f165a161506782ab2b10; existing debt #393/#394/#397/#398/#399/#401/#402/#403 reused
- categorical design final main: e1d0df204ecf49322b6d932ffbf5e23daa629a29; dependency/build warning debt #141 reused
- all 44 sourceRefs returned HTTP 200

## Decisions

- set the prerequisites bridge estimatedWeeks to the explicitly named standard route (6-8週間); keep the textbook and categorical book null because their sources provide conflicting duration guidance or only hours/days
- set prerequisites-book recommendedAfter to the TCS textbook and keep textbook prerequisites pointed to the prerequisites book; remove the prior reciprocal recommendedAfter
- classify the prerequisites bridge as beginner/intermediate from its prerequisite-diagnostic and Core/Standard routes
- retain categorical-software-design-book as an independent related Japanese book, not a translation/version of composable-software-design-book
- record the prerequisites book's missing concept map as approved debt with tracking Issue #223 instead of claiming the reverse concept index is a map
- keep the main textbook reviewStatus at review-needed and lastReviewedAt null until the open P0 content fixes (#397/#398/#399/#401/#402) merge; retain reviewIssue #222 as the metadata/publication audit evidence

## Debt delta

- empty summary.ja: 18 → 16
- missing review date: 28 → 26
- missing review Issue: 27 → 24
- provisional notes: 18 → 16
- missing estimatedWeeks: 41 → 40
- required UX debt: 19 → 20; baseline/current 20/20, unapproved 0, stale 0
- reader-view leaks: 0

## Verification

- npm ci (0 vulnerabilities)
- npm run generate
- npm run verify
  - catalog 49 / learning paths 7
  - catalog debt tests 11/11
  - production smoke tests 8/8
  - Pages drift tests 7/7
  - Playwright 45/45, no axe violations
- node scripts/validate-ux-registry.js (41 books)
- npm audit --audit-level=moderate (0 vulnerabilities)
- sourceRefs HTTP audit (44/44)
- built JA/EN summary marker checks
- reader operational-metadata leak check (0)
- git diff --check

Closes #222


