### PR TITLE
docs: GitHub関連3冊のcatalog監査を確定する

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -2056,29 +2056,35 @@
         "development-delivery"
       ],
       "levels": [
-        "all-levels"
+        "beginner",
+        "intermediate"
       ],
       "roles": [
         "software-engineer",
         "engineering-manager"
       ],
       "audiences": [
-        "全レベル / 開発効率化・品質向上"
+        "プログラミング初心者で、バージョン管理の必要性とGit／GitHubの基本を学びたい方",
+        "チーム開発のスキルを身につけたい学生・研究者",
+        "GitHubによる文書管理・プロジェクト管理を学びたい非エンジニア",
+        "チーム全体のGitHubスキル向上を検討する企業研修担当者"
       ],
       "summary": {
-        "ja": "",
-        "en": "Introduces GitHub basics for repositories, branching, pull requests, and team collaboration."
+        "ja": "GitとGitHubを初めて学ぶ読者が、リポジトリ、コミット、ブランチ、Pull Requestの基本から、チーム開発、Actions、セキュリティ、トラブル対応までを実習を通して体系的に習得するための入門書です。",
+        "en": "A hands-on introduction for readers new to Git and GitHub, covering repositories, commits, branches, pull requests, team collaboration, Actions, security, and troubleshooting."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "github-workflow-book"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 226,
       "ux": {
         "profile": "A",
         "modules": {
@@ -2086,23 +2092,28 @@
           "readingGuide": true,
           "checklistPack": false,
           "troubleshootingFlow": false,
-          "conceptMap": true,
+          "conceptMap": false,
           "figureIndex": false,
-          "legalNotice": false,
-          "glossary": true
+          "legalNotice": true,
+          "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#226とsource修正itdojp/github-guide-for-beginners-book#226 / PR #227で、source main 052ddbe2e279cf1e87f2e2c18351814233b93ffcのREADME、book-config、公開トップ、導入、学習リソース、公開Pagesを照合し、対象読者、初級〜中級、Profile A、modulesを確定。公開トップの通読6〜12時間・演習込み12〜24時間と、導入の基本操作約1週間・チーム開発追加1週間・高度な活用は必要に応じてという複数目安は、書籍全体を閉じた単一の標準週数ではないためestimatedWeeksはnullとした。学習ロードマップ図は章内図版で独立したconcept map moduleではなく、専用用語集も未実装のためfalse。Profile A必須の用語導線はitdojp/it-engineer-knowledge-architecture#227で追跡する。Ruby 3.4・Sass/minima warningはitdojp/github-guide-for-beginners-book#225へ分離した。付録の明示導線に基づきgithub-workflow-bookを次読とした。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/github-guide-for-beginners-book/blob/052ddbe2e279cf1e87f2e2c18351814233b93ffc/README.md",
+        "https://github.com/itdojp/github-guide-for-beginners-book/blob/052ddbe2e279cf1e87f2e2c18351814233b93ffc/book-config.json",
+        "https://github.com/itdojp/github-guide-for-beginners-book/blob/052ddbe2e279cf1e87f2e2c18351814233b93ffc/docs/index.md",
+        "https://github.com/itdojp/github-guide-for-beginners-book/blob/052ddbe2e279cf1e87f2e2c18351814233b93ffc/docs/chapters/chapter-introduction/index.md",
+        "https://github.com/itdojp/github-guide-for-beginners-book/blob/052ddbe2e279cf1e87f2e2c18351814233b93ffc/docs/appendices/appendix-resources/index.md",
+        "https://itdojp.github.io/github-guide-for-beginners-book/",
+        "https://github.com/itdojp/github-guide-for-beginners-book/issues/225",
+        "https://github.com/itdojp/github-guide-for-beginners-book/issues/226",
+        "https://github.com/itdojp/github-guide-for-beginners-book/pull/227",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/226"
       ]
     },
     {
@@ -2127,53 +2138,70 @@
         "development-delivery"
       ],
       "levels": [
-        "all-levels"
+        "intermediate",
+        "advanced"
       ],
       "roles": [
         "software-engineer",
-        "engineering-manager"
+        "architect",
+        "engineering-manager",
+        "security-engineer"
       ],
       "audiences": [
-        "全レベル / 開発効率化・品質向上"
+        "GitHubを中心にチーム開発を行い、AI支援開発を含む運用を整理したいエンジニア",
+        "PR運用、CI/CD、セキュリティを含む開発標準を整備するテックリード／アーキテクト",
+        "権限設計やレビュー体制をガバナンス／コンプライアンス観点で見直す担当者"
       ],
       "summary": {
-        "ja": "",
-        "en": "Shows how to use GitHub workflows, automation, and AI-assisted review in modern software delivery."
+        "ja": "GitHubを使う開発チームや標準化担当者が、AI支援開発を前提としたIssue・PR・レビュー、Actions、CI/CD、権限、セキュリティ、ガバナンスの設計と改善を体系的に学ぶ実践書です。",
+        "en": "A practical guide for engineering teams and standards owners designing AI-assisted GitHub delivery, from issues, pull requests, reviews, and Actions to CI/CD, permissions, security, and governance."
       },
-      "prerequisites": [],
+      "prerequisites": [
+        "github-guide-for-beginners-book"
+      ],
       "estimatedWeeks": null,
-      "recommendedAfter": [],
+      "recommendedAfter": [
+        "GitHub-AgentOps-book"
+      ],
       "languages": [
         "ja"
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 226,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
-          "checklistPack": true,
+          "readingGuide": true,
+          "checklistPack": false,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
-          "legalNotice": false,
-          "glossary": false
+          "figureIndex": false,
+          "legalNotice": true,
+          "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#226とsource修正itdojp/github-workflow-book#236 / #238、PR #237 / #239で、source main 2996cdac4eca5a8d611f71818741de4cdfd10511のREADME、book-config、公開トップ、第6章、用語集、トラブルシューティング、公開Pagesを照合し、対象読者、中級〜上級、Profile B、modulesを確定。公開トップがGitHub初心者ガイドを前提と明記するためprerequisitesへ設定し、第6章が運用設計の詳細を公開済みAgentOps本へ委譲するためrecommendedAfterへ設定した。通読2〜2.5時間は週単位の標準計画ではないためestimatedWeeksはnull。専用チェックリスト集と図表索引は未実装のためitdojp/it-engineer-knowledge-architecture#227で追跡する。npm allowScriptsとFaraday warningはitdojp/github-workflow-book#235へ分離した。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/github-workflow-book/blob/2996cdac4eca5a8d611f71818741de4cdfd10511/README.md",
+        "https://github.com/itdojp/github-workflow-book/blob/2996cdac4eca5a8d611f71818741de4cdfd10511/book-config.json",
+        "https://github.com/itdojp/github-workflow-book/blob/2996cdac4eca5a8d611f71818741de4cdfd10511/docs/index.md",
+        "https://github.com/itdojp/github-workflow-book/blob/2996cdac4eca5a8d611f71818741de4cdfd10511/docs/chapters/chapter06/index.md",
+        "https://github.com/itdojp/github-workflow-book/blob/2996cdac4eca5a8d611f71818741de4cdfd10511/docs/appendices/appendix-a/index.md",
+        "https://github.com/itdojp/github-workflow-book/blob/2996cdac4eca5a8d611f71818741de4cdfd10511/docs/appendices/appendix-b/index.md",
+        "https://itdojp.github.io/github-workflow-book/",
+        "https://github.com/itdojp/github-workflow-book/issues/235",
+        "https://github.com/itdojp/github-workflow-book/issues/236",
+        "https://github.com/itdojp/github-workflow-book/issues/238",
+        "https://github.com/itdojp/github-workflow-book/pull/237",
+        "https://github.com/itdojp/github-workflow-book/pull/239",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/226"
       ]
     },
     {
@@ -2183,7 +2211,7 @@
         "ja": "GitHub AgentOps 実践ガイド",
         "en": "GitHub AgentOps 実践ガイド"
       },
-      "officialEnglishTitle": null,
+      "officialEnglishTitle": "GitHub AgentOps Practical Guide",
       "status": "published",
       "repo": "itdojp/GitHub-AgentOps-book",
       "repoVisibility": "public",
@@ -2198,18 +2226,24 @@
         "development-delivery"
       ],
       "levels": [
-        "all-levels"
+        "intermediate",
+        "advanced"
       ],
       "roles": [
         "software-engineer",
-        "engineering-manager"
+        "architect",
+        "engineering-manager",
+        "security-engineer",
+        "sre"
       ],
       "audiences": [
-        "全レベル / 開発効率化・品質向上"
+        "AIエージェント開発の標準化、統制、レビュー設計を担う開発リーダー／テックリード",
+        "CI、権限、品質ゲートを運用する中〜大規模開発のメンテナー",
+        "運用設計と自動化を担うSRE／DevEx／Platform Engineering担当者"
       ],
       "summary": {
-        "ja": "",
-        "en": "Organizes GitHub-centered AgentOps practices for prompts, reviews, governance, and operational control of AI agents."
+        "ja": "テックリード、メンテナー、SRE／Platform Engineering担当者が、AIエージェントをGitHub上で安全かつ監査可能に運用するための責任分界、指示設計、CI、権限、供給網、コスト、運用評価を実装可能な形で学ぶ実践書です。",
+        "en": "A practical guide for leads, maintainers, SRE, and platform teams operating AI agents on GitHub with auditable responsibility boundaries, instructions, CI, permissions, supply-chain controls, cost governance, and operational review."
       },
       "prerequisites": [],
       "estimatedWeeks": null,
@@ -2219,32 +2253,41 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": null,
-      "reviewIssue": null,
+      "lastReviewedAt": "2026-07-12",
+      "reviewIssue": 226,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
-          "readingGuide": false,
+          "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": true,
-          "legalNotice": false,
+          "figureIndex": false,
+          "legalNotice": true,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-10",
+      "updatedAt": "2026-07-12",
       "notes": [
-        "暫定割当（要確認）",
-        "日本語個別概要はREADME公開カタログ上で未記載。",
-        "UX profile/modules は移行元 book-registry の暫定割当を維持。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#226、dependency修正itdojp/GitHub-AgentOps-book#54 / PR #56、UX修正itdojp/GitHub-AgentOps-book#57 / PR #58で、source main e55a4620dadf014a051c9e591f552e5f92a2153bのREADME、book-config、公開トップ、セキュリティ章、テンプレート、プレイブック、トラブルシューティング、公開Pagesを照合し、正式英語書名、対象読者、中級〜上級、Profile B、modulesを確定。通読2〜3時間・導入半日〜1日は週単位の標準計画ではないためestimatedWeeksはnull。GitHub基礎とCIは知識要件であり特定書籍の修了を必須としないためprerequisitesは空。関連書籍のworkflow本は補完資料であり循環的な次読にしない。専用図表索引は未実装のためitdojp/it-engineer-knowledge-architecture#227で追跡する。npm audit 10件は0へ解消し、残るFaraday・whatwg-encoding warningはitdojp/GitHub-AgentOps-book#55へ分離した。"
       ],
       "sourceRefs": [
-        "README.md",
-        "docs/en/index.md",
-        "docs/publishing/book-registry.json"
+        "https://github.com/itdojp/GitHub-AgentOps-book/blob/e55a4620dadf014a051c9e591f552e5f92a2153b/README.md",
+        "https://github.com/itdojp/GitHub-AgentOps-book/blob/e55a4620dadf014a051c9e591f552e5f92a2153b/book-config.json",
+        "https://github.com/itdojp/GitHub-AgentOps-book/blob/e55a4620dadf014a051c9e591f552e5f92a2153b/docs/index.md",
+        "https://github.com/itdojp/GitHub-AgentOps-book/blob/e55a4620dadf014a051c9e591f552e5f92a2153b/docs/chapters/chapter10/index.md",
+        "https://github.com/itdojp/GitHub-AgentOps-book/blob/e55a4620dadf014a051c9e591f552e5f92a2153b/docs/appendices/appendix-a/index.md",
+        "https://github.com/itdojp/GitHub-AgentOps-book/blob/e55a4620dadf014a051c9e591f552e5f92a2153b/docs/appendices/appendix-b/index.md",
+        "https://github.com/itdojp/GitHub-AgentOps-book/blob/e55a4620dadf014a051c9e591f552e5f92a2153b/docs/appendices/appendix-c/index.md",
+        "https://itdojp.github.io/GitHub-AgentOps-book/",
+        "https://github.com/itdojp/GitHub-AgentOps-book/issues/54",
+        "https://github.com/itdojp/GitHub-AgentOps-book/issues/55",
+        "https://github.com/itdojp/GitHub-AgentOps-book/issues/57",
+        "https://github.com/itdojp/GitHub-AgentOps-book/pull/56",
+        "https://github.com/itdojp/GitHub-AgentOps-book/pull/58",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/226"
       ]
     },
     {

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -247,15 +247,15 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
+        "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
+        "figureIndex": false,
+        "legalNotice": true,
         "glossary": false
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#226、dependency修正itdojp/GitHub-AgentOps-book#54 / PR #56、UX修正itdojp/GitHub-AgentOps-book#57 / PR #58で、source main e55a4620dadf014a051c9e591f552e5f92a2153bのREADME、book-config、公開トップ、セキュリティ章、テンプレート、プレイブック、トラブルシューティング、公開Pagesを照合し、正式英語書名、対象読者、中級〜上級、Profile B、modulesを確定。通読2〜3時間・導入半日〜1日は週単位の標準計画ではないためestimatedWeeksはnull。GitHub基礎とCIは知識要件であり特定書籍の修了を必須としないためprerequisitesは空。関連書籍のworkflow本は補完資料であり循環的な次読にしない。専用図表索引は未実装のためitdojp/it-engineer-knowledge-architecture#227で追跡する。npm audit 10件は0へ解消し、残るFaraday・whatwg-encoding warningはitdojp/GitHub-AgentOps-book#55へ分離した。"
     },
     "github-guide-for-beginners-book": {
       "repo": "itdojp/github-guide-for-beginners-book",
@@ -266,12 +266,12 @@
         "readingGuide": true,
         "checklistPack": false,
         "troubleshootingFlow": false,
-        "conceptMap": true,
+        "conceptMap": false,
         "figureIndex": false,
-        "legalNotice": false,
-        "glossary": true
+        "legalNotice": true,
+        "glossary": false
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#226とsource修正itdojp/github-guide-for-beginners-book#226 / PR #227で、source main 052ddbe2e279cf1e87f2e2c18351814233b93ffcのREADME、book-config、公開トップ、導入、学習リソース、公開Pagesを照合し、対象読者、初級〜中級、Profile A、modulesを確定。公開トップの通読6〜12時間・演習込み12〜24時間と、導入の基本操作約1週間・チーム開発追加1週間・高度な活用は必要に応じてという複数目安は、書籍全体を閉じた単一の標準週数ではないためestimatedWeeksはnullとした。学習ロードマップ図は章内図版で独立したconcept map moduleではなく、専用用語集も未実装のためfalse。Profile A必須の用語導線はitdojp/it-engineer-knowledge-architecture#227で追跡する。Ruby 3.4・Sass/minima warningはitdojp/github-guide-for-beginners-book#225へ分離した。付録の明示導線に基づきgithub-workflow-bookを次読とした。"
     },
     "github-workflow-book": {
       "repo": "itdojp/github-workflow-book",
@@ -279,15 +279,15 @@
       "profile": "B",
       "modules": {
         "quickStart": false,
-        "readingGuide": false,
-        "checklistPack": true,
+        "readingGuide": true,
+        "checklistPack": false,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": true,
-        "legalNotice": false,
-        "glossary": false
+        "figureIndex": false,
+        "legalNotice": true,
+        "glossary": true
       },
-      "notes": "暫定割当（要確認）"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#226とsource修正itdojp/github-workflow-book#236 / #238、PR #237 / #239で、source main 2996cdac4eca5a8d611f71818741de4cdfd10511のREADME、book-config、公開トップ、第6章、用語集、トラブルシューティング、公開Pagesを照合し、対象読者、中級〜上級、Profile B、modulesを確定。公開トップがGitHub初心者ガイドを前提と明記するためprerequisitesへ設定し、第6章が運用設計の詳細を公開済みAgentOps本へ委譲するためrecommendedAfterへ設定した。通読2〜2.5時間は週単位の標準計画ではないためestimatedWeeksはnull。専用チェックリスト集と図表索引は未実装のためitdojp/it-engineer-knowledge-architecture#227で追跡する。npm allowScriptsとFaraday warningはitdojp/github-workflow-book#235へ分離した。"
     },
     "illustrated-linux-basics-book": {
       "repo": "itdojp/illustrated-linux-basics-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -10,10 +10,9 @@
   },
   "debt": {
     "emptySummaryJa": {
-      "count": 16,
+      "count": 13,
       "bookIds": [
         "BioinformaticsGuide-book",
-        "GitHub-AgentOps-book",
         "IT-engineer-communication-book",
         "LogicalThinking-AI-Era-Guide",
         "ai-agent-engineering-book",
@@ -24,8 +23,6 @@
         "cs-visionaries-book",
         "ethereum-learning-bootcamp",
         "formal-methods-book",
-        "github-guide-for-beginners-book",
-        "github-workflow-book",
         "negotiation-for-engineers-book",
         "small-webapp-software-design-book"
       ]
@@ -88,10 +85,9 @@
       ]
     },
     "missingLastReviewedAt": {
-      "count": 26,
+      "count": 23,
       "bookIds": [
         "BioinformaticsGuide-book",
-        "GitHub-AgentOps-book",
         "IT-engineer-communication-book",
         "LogicalThinking-AI-Era-Guide",
         "ai-agent-collaboration-book",
@@ -107,8 +103,6 @@
         "enterprise-cloud-architecture-guide",
         "ethereum-learning-bootcamp",
         "formal-methods-book",
-        "github-guide-for-beginners-book",
-        "github-workflow-book",
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
         "negotiation-for-engineers-book",
@@ -119,10 +113,9 @@
       ]
     },
     "missingReviewIssue": {
-      "count": 24,
+      "count": 21,
       "bookIds": [
         "BioinformaticsGuide-book",
-        "GitHub-AgentOps-book",
         "IT-engineer-communication-book",
         "LogicalThinking-AI-Era-Guide",
         "ai-agent-collaboration-book",
@@ -137,8 +130,6 @@
         "enterprise-cloud-architecture-guide",
         "ethereum-learning-bootcamp",
         "formal-methods-book",
-        "github-guide-for-beginners-book",
-        "github-workflow-book",
         "infrastructure-monitoring-automation-guide",
         "infrastructure-performance-capacity-planning",
         "negotiation-for-engineers-book",
@@ -148,18 +139,10 @@
       ]
     },
     "provisionalNotes": {
-      "count": 16,
+      "count": 13,
       "books": [
         {
           "id": "BioinformaticsGuide-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
-          "id": "GitHub-AgentOps-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
             "日本語個別概要はREADME公開カタログ上で未記載。",
@@ -246,22 +229,6 @@
           ]
         },
         {
-          "id": "github-guide-for-beginners-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
-          "id": "github-workflow-book",
-          "notes": [
-            "UX profile/modules は移行元 book-registry の暫定割当を維持。",
-            "日本語個別概要はREADME公開カタログ上で未記載。",
-            "暫定割当（要確認）"
-          ]
-        },
-        {
           "id": "negotiation-for-engineers-book",
           "notes": [
             "UX profile/modules は移行元 book-registry の暫定割当を維持。",
@@ -332,10 +299,9 @@
       ]
     },
     "uxEvidenceCandidates": {
-      "count": 17,
+      "count": 14,
       "bookIds": [
         "BioinformaticsGuide-book",
-        "GitHub-AgentOps-book",
         "IT-engineer-communication-book",
         "LogicalThinking-AI-Era-Guide",
         "ai-agent-engineering-book",
@@ -347,16 +313,26 @@
         "cs-visionaries-book",
         "ethereum-learning-bootcamp",
         "formal-methods-book",
-        "github-guide-for-beginners-book",
-        "github-workflow-book",
         "negotiation-for-engineers-book",
         "small-webapp-software-design-book"
       ]
     },
     "missingRequiredUxModules": {
-      "count": 20,
-      "bookCount": 17,
+      "count": 24,
+      "bookCount": 20,
       "books": [
+        {
+          "id": "GitHub-AgentOps-book",
+          "profile": "B",
+          "missingModules": [
+            {
+              "module": "figureIndex",
+              "reason": "実ファイルと公開Pages監査で専用の図表索引が未実装であることを確認済み。章内図表を索引として扱わず、根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 226,
+              "trackingIssue": 227
+            }
+          ]
+        },
         {
           "id": "IT-infra-book",
           "profile": "B",
@@ -390,6 +366,36 @@
               "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 193,
               "trackingIssue": 197
+            }
+          ]
+        },
+        {
+          "id": "github-guide-for-beginners-book",
+          "profile": "A",
+          "missingModules": [
+            {
+              "module": "glossary",
+              "reason": "実ファイルと公開Pages監査で専用の用語導線が未実装であることを確認済み。章内の用語説明を独立した用語集として扱わず、根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 226,
+              "trackingIssue": 227
+            }
+          ]
+        },
+        {
+          "id": "github-workflow-book",
+          "profile": "B",
+          "missingModules": [
+            {
+              "module": "checklistPack",
+              "reason": "実ファイルと公開Pages監査で独立したチェックリスト集が未実装であることを確認済み。章内の確認項目を専用moduleとして扱わず、根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 226,
+              "trackingIssue": 227
+            },
+            {
+              "module": "figureIndex",
+              "reason": "実ファイルと公開Pages監査で専用の図表索引が未実装であることを確認済み。個別図版を索引として扱わず、根拠のないtrueへの変更は行わない。",
+              "evidenceIssue": 226,
+              "trackingIssue": 227
             }
           ]
         },
@@ -588,8 +594,8 @@
   },
   "gates": {
     "requiredUxModuleDebt": {
-      "baselineCount": 20,
-      "currentCount": 20,
+      "baselineCount": 24,
+      "currentCount": 24,
       "unapprovedCount": 0,
       "unapproved": [],
       "staleBaselineCount": 0,

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -160,6 +160,38 @@
       "reason": "実ファイルと公開Pages監査で専用の概念マップが未実装であることを確認済み。概念別逆引きは詰まり方から参照先を探す索引であり、概念・章間依存を俯瞰するmapとして代用せず、根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 222,
       "trackingIssue": 223
+    },
+    {
+      "bookId": "github-guide-for-beginners-book",
+      "profile": "A",
+      "module": "glossary",
+      "reason": "実ファイルと公開Pages監査で専用の用語導線が未実装であることを確認済み。章内の用語説明を独立した用語集として扱わず、根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 226,
+      "trackingIssue": 227
+    },
+    {
+      "bookId": "github-workflow-book",
+      "profile": "B",
+      "module": "checklistPack",
+      "reason": "実ファイルと公開Pages監査で独立したチェックリスト集が未実装であることを確認済み。章内の確認項目を専用moduleとして扱わず、根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 226,
+      "trackingIssue": 227
+    },
+    {
+      "bookId": "github-workflow-book",
+      "profile": "B",
+      "module": "figureIndex",
+      "reason": "実ファイルと公開Pages監査で専用の図表索引が未実装であることを確認済み。個別図版を索引として扱わず、根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 226,
+      "trackingIssue": 227
+    },
+    {
+      "bookId": "GitHub-AgentOps-book",
+      "profile": "B",
+      "module": "figureIndex",
+      "reason": "実ファイルと公開Pages監査で専用の図表索引が未実装であることを確認済み。章内図表を索引として扱わず、根拠のないtrueへの変更は行わない。",
+      "evidenceIssue": 226,
+      "trackingIssue": 227
     }
   ]
 }


### PR DESCRIPTION
## 概要

Quality Sprint #226 として、displayOrder 25〜27 のGitHub関連3冊を固定source SHA・公開Pagesで監査し、catalog metadata、学習方向、UX debt baseline、生成物を更新します。

Closes #226

## 対象

- GitHub初心者ガイド
- AI開発のためのGitHubワークフロー実践ガイド
- GitHub AgentOps 実践ガイド

## 変更

- 日英概要、想定読者、levels / roles、レビュー証跡、固定SHA sourceRefs、監査notesを確定
- 明示根拠に基づき `github-guide-for-beginners-book → github-workflow-book → GitHub-AgentOps-book` の非循環方向を設定
- 3冊とも書籍全体の単一標準週数がないため `estimatedWeeks=null`
- source側先行修正後のUX modulesへ同期
- 未実装required module 4件を #227 の追跡根拠付きでbaseline化
- registry / catalog debt reportを再生成

## Source先行修正

- guide #226 / PR #227 → `052ddbe2e279cf1e87f2e2c18351814233b93ffc`
- workflow #236 / PR #237、#238 / PR #239 → `2996cdac4eca5a8d611f71818741de4cdfd10511`
- AgentOps #54 / PR #56、#57 / PR #58 → `e55a4620dadf014a051c9e591f552e5f92a2153b`

## 検証

- `npm ci`
- `npm run generate`
- `npm run verify`（catalog 49 / paths 7、debt 11/11、production smoke 8/8、drift 7/7、Playwright 45/45）
- `node scripts/validate-ux-registry.js`（41 books）
- `npm audit --audit-level=moderate`（0 vulnerabilities）
- 対象3冊の全sourceRefs HTTP 200
- reader-facing JA/EN markerと運用metadata非露出
- `git diff --check`
- 独立reviewerのModerate 1件を反映後、再レビューでactionable finding 0

## Debt差分

- empty summary.ja: 16 → 13
- missing review date: 26 → 23
- missing review Issue: 24 → 21
- provisional notes: 16 → 13
- missing estimatedWeeks: 40 → 40
- required UX modules: 20 → 24
- baseline/current 24/24、unapproved/stale 0/0、reader leak 0

## 継続追跡

- UX: #227
- 既存 #210 / #212 / #215 / #220 / #223 は変更なし
- source warnings: guide #225、workflow #235、AgentOps #55
