### PR TITLE
docs: assign open tracker to remaining UX debt

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -476,7 +476,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がないためfigureIndex=falseとし、必須module debtは#197で追跡する。"
+        "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がないためfigureIndex=falseとし、必須module debtの実装は#250で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/README.md",
@@ -557,7 +557,7 @@
       "addedAt": null,
       "updatedAt": "2026-07-12",
       "notes": [
-        "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がないためfigureIndex=falseとし、必須module debtは#197で追跡する。"
+        "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がないためfigureIndex=falseとし、必須module debtの実装は#250で追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/README.md",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -321,7 +321,7 @@
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がないためfigureIndex=falseとし、必須module debtは#197で追跡する。"
+      "notes": "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がないためfigureIndex=falseとし、必須module debtの実装は#250で追跡する。"
     },
     "issue-driven-work-book": {
       "repo": "itdojp/issue-driven-work-book",
@@ -593,7 +593,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がないためfigureIndex=falseとし、必須module debtは#197で追跡する。"
+      "notes": "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がないためfigureIndex=falseとし、必須module debtの実装は#250で追跡する。"
     },
     "small-webapp-software-design-book": {
       "repo": "itdojp/small-webapp-software-design-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -311,7 +311,7 @@
               "module": "figureIndex",
               "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 193,
-              "trackingIssue": 197
+              "trackingIssue": 250
             }
           ]
         },
@@ -353,7 +353,7 @@
               "module": "figureIndex",
               "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 205,
-              "trackingIssue": 197
+              "trackingIssue": 250
             }
           ]
         },
@@ -365,7 +365,7 @@
               "module": "glossary",
               "reason": "実ファイル監査で専用の用語導線が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 193,
-              "trackingIssue": 197
+              "trackingIssue": 250
             }
           ]
         },
@@ -521,7 +521,7 @@
               "module": "figureIndex",
               "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 205,
-              "trackingIssue": 197
+              "trackingIssue": 250
             }
           ]
         },

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -23,7 +23,7 @@
       "module": "figureIndex",
       "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 193,
-      "trackingIssue": 197
+      "trackingIssue": 250
     },
     {
       "bookId": "incident-response-basics-book",
@@ -31,7 +31,7 @@
       "module": "figureIndex",
       "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 205,
-      "trackingIssue": 197
+      "trackingIssue": 250
     },
     {
       "bookId": "issue-driven-work-book",
@@ -39,7 +39,7 @@
       "module": "glossary",
       "reason": "実ファイル監査で専用の用語導線が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 193,
-      "trackingIssue": 197
+      "trackingIssue": 250
     },
     {
       "bookId": "it-infra-security-guide-book",
@@ -127,7 +127,7 @@
       "module": "figureIndex",
       "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
       "evidenceIssue": 205,
-      "trackingIssue": 197
+      "trackingIssue": 250
     },
     {
       "bookId": "podman-book",


### PR DESCRIPTION
## 概要

Related to #250
Parent: #187

#197はrequired UX debtの集計・baseline・再増加防止gateを実装して完了した仕組み側Issueです。4件のreader-facing module実装は未完了であるため、baselineのtrackingIssueを新しいopen実装Issue #250へ移します。

## 変更

- engineering-documentation-book / Profile B / figureIndex
- incident-response-basics-book / Profile B / figureIndex
- issue-driven-work-book / Profile A / glossary
- security-privacy-literacy-book / Profile B / figureIndex
- 上記4 entryのtrackingIssueを197から250へ変更
- generated debt reportを同期

## 検証

- npm ci: audit 0
- npm run generate
- npm run verify: catalog49 / paths7、debt11、completion6、production smoke8、drift7、Playwright45
- UX registry: 41 books
- baseline/current: 41/41
- unapproved/stale: 0/0
- git diff --check
