### PR TITLE
docs: resolve TCS prerequisite concept map debt

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1825,8 +1825,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
-      "reviewIssue": 222,
+      "lastReviewedAt": "2026-07-13",
+      "reviewIssue": 223,
       "ux": {
         "profile": "C",
         "modules": {
@@ -1834,33 +1834,40 @@
           "readingGuide": true,
           "checklistPack": true,
           "troubleshootingFlow": false,
-          "conceptMap": false,
+          "conceptMap": true,
           "figureIndex": true,
           "legalNotice": false,
           "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-12",
+      "updatedAt": "2026-07-13",
       "notes": [
-        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222とsource修正itdojp/theoretical-computer-science-prerequisites-book#5 / #7、PR #6 / #8で、source main a6b193c0546630fa580998b04ad90ca067194a80のREADME、book-config、公開トップ、学習パス、前提診断、本体対応表、索引を照合し、対象読者、初級〜中級、Profile C、modulesを確定。前提教材から本体教科書への明示導線に基づきrecommendedAfterを設定した。本文が標準ルートをCoreとStandard中心の6〜8週間と明示しているためestimatedWeeksを6-8週間とし、最短2〜4週と拡張10〜12週は代替ルートとしてnotesに保持する。専用concept mapは未実装のためitdojp/it-engineer-knowledge-architecture#223で分離追跡し、逆引きconcept indexを代用してtrueにはしない。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222で対象読者、初級〜中級、Profile C、学習方向、標準6〜8週間を確定。2026-07-13のUX debt #223とsource itdojp/theoretical-computer-science-prerequisites-book#9 / PR #10で、source main 332ae88bffebf54a0bd5237048fa17cd2665aa92へreader-facingな専用概念依存マップを実装し、公開トップ、学習ルート、ナビゲーションガイド、sidebar、site searchから到達可能であることをPages本番確認した。概念別逆引き、学習ルート、章間リンクマップ、本体教科書からの逆引き、本体教科書との対応表との責務を分離し、conceptMap=trueへ更新した。"
       ],
       "sourceRefs": [
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/README.md",
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/book-config.json",
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/index.md",
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/_data/navigation.yml",
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/learning-path.md",
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/appendix/mapping-to-main-textbook.md",
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/reference/concept-index.md",
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/reference/glossary.md",
-        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/a6b193c0546630fa580998b04ad90ca067194a80/docs/reference/symbol-index.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/README.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/book-config.json",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/index.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/_data/navigation.yml",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/learning-path.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/appendix/mapping-to-main-textbook.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/reference/concept-index.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/reference/glossary.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/reference/symbol-index.md",
         "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/issues/5",
         "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/pull/6",
         "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/issues/7",
         "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/pull/8",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/222",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/223"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/223",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/reference/concept-map.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/issues/9",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/pull/10",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/navigation/navigation-guide.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/navigation/main-textbook-reverse-index.md",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/docs/assets/search-data.json",
+        "https://github.com/itdojp/theoretical-computer-science-prerequisites-book/blob/332ae88bffebf54a0bd5237048fa17cd2665aa92/tests/test_project_layout.py"
       ]
     },
     {

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -636,12 +636,12 @@
         "readingGuide": true,
         "checklistPack": true,
         "troubleshootingFlow": false,
-        "conceptMap": false,
+        "conceptMap": true,
         "figureIndex": true,
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222とsource修正itdojp/theoretical-computer-science-prerequisites-book#5 / #7、PR #6 / #8で、source main a6b193c0546630fa580998b04ad90ca067194a80のREADME、book-config、公開トップ、学習パス、前提診断、本体対応表、索引を照合し、対象読者、初級〜中級、Profile C、modulesを確定。前提教材から本体教科書への明示導線に基づきrecommendedAfterを設定した。本文が標準ルートをCoreとStandard中心の6〜8週間と明示しているためestimatedWeeksを6-8週間とし、最短2〜4週と拡張10〜12週は代替ルートとしてnotesに保持する。専用concept mapは未実装のためitdojp/it-engineer-knowledge-architecture#223で分離追跡し、逆引きconcept indexを代用してtrueにはしない。"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#222で対象読者、初級〜中級、Profile C、学習方向、標準6〜8週間を確定。2026-07-13のUX debt #223とsource itdojp/theoretical-computer-science-prerequisites-book#9 / PR #10で、source main 332ae88bffebf54a0bd5237048fa17cd2665aa92へreader-facingな専用概念依存マップを実装し、公開トップ、学習ルート、ナビゲーションガイド、sidebar、site searchから到達可能であることをPages本番確認した。概念別逆引き、学習ルート、章間リンクマップ、本体教科書からの逆引き、本体教科書との対応表との責務を分離し、conceptMap=trueへ更新した。"
     },
     "theoretical-computer-science-textbook": {
       "repo": "itdojp/theoretical-computer-science-textbook",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -138,8 +138,8 @@
       "bookIds": []
     },
     "missingRequiredUxModules": {
-      "count": 41,
-      "bookCount": 29,
+      "count": 40,
+      "bookCount": 28,
       "books": [
         {
           "id": "BioinformaticsGuide-book",
@@ -548,18 +548,6 @@
               "trackingIssue": 220
             }
           ]
-        },
-        {
-          "id": "theoretical-computer-science-prerequisites-book",
-          "profile": "C",
-          "missingModules": [
-            {
-              "module": "conceptMap",
-              "reason": "実ファイルと公開Pages監査で専用の概念マップが未実装であることを確認済み。概念別逆引きは詰まり方から参照先を探す索引であり、概念・章間依存を俯瞰するmapとして代用せず、根拠のないtrueへの変更は行わない。",
-              "evidenceIssue": 222,
-              "trackingIssue": 223
-            }
-          ]
         }
       ]
     },
@@ -570,8 +558,8 @@
   },
   "gates": {
     "requiredUxModuleDebt": {
-      "baselineCount": 41,
-      "currentCount": 41,
+      "baselineCount": 40,
+      "currentCount": 40,
       "unapprovedCount": 0,
       "unapproved": [],
       "staleBaselineCount": 0,

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -154,14 +154,6 @@
       "trackingIssue": 220
     },
     {
-      "bookId": "theoretical-computer-science-prerequisites-book",
-      "profile": "C",
-      "module": "conceptMap",
-      "reason": "実ファイルと公開Pages監査で専用の概念マップが未実装であることを確認済み。概念別逆引きは詰まり方から参照先を探す索引であり、概念・章間依存を俯瞰するmapとして代用せず、根拠のないtrueへの変更は行わない。",
-      "evidenceIssue": 222,
-      "trackingIssue": 223
-    },
-    {
       "bookId": "github-guide-for-beginners-book",
       "profile": "A",
       "module": "glossary",


### PR DESCRIPTION
## Summary

- update the TCS prerequisites catalog record to the source implementation merged at `332ae88bffebf54a0bd5237048fa17cd2665aa92`
- set the verified Profile C `conceptMap` module to `true`
- refresh review evidence, notes, and fixed-SHA source references
- remove the resolved concept-map baseline entry and regenerate registry/debt artifacts

## Source evidence

- source Issue: itdojp/theoretical-computer-science-prerequisites-book#9
- source PR: itdojp/theoretical-computer-science-prerequisites-book#10
- source final SHA: `332ae88bffebf54a0bd5237048fa17cd2665aa92`
- source Book QA `29216144233`: success
- source Deploy Pages `29216144212`: success
- public `/reference/concept-map/`, home, learning path, navigation guide, sidebar active state, search entry, and metadata verified

## Debt impact

- required UX debt: 41 → 40
- affected books: 29 → 28
- baseline/current: 40/40
- unapproved/stale: 0/0
- reader-view leaks: 0

## Verification

- `npm ci`
- `npm run generate`
- `npm run verify` — catalog 49, paths 7, debt 11, completion 6, smoke 8, drift 7, Playwright 45/45
- `node scripts/validate-ux-registry.js` — 41 books
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- sourceRefs 22/22 HTTP success
- independent review: no actionable findings
- `git diff --check`

Closes #223
