### PR TITLE
docs: resolve negotiation and communication UX debt

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -3107,16 +3107,16 @@
       "relatedEditions": [],
       "reviewStatus": "reviewed",
       "lastReviewedAt": "2026-07-13",
-      "reviewIssue": 238,
+      "reviewIssue": 239,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": false,
           "readingGuide": true,
           "checklistPack": true,
-          "troubleshootingFlow": false,
+          "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": false,
+          "figureIndex": true,
           "legalNotice": false,
           "glossary": true
         }
@@ -3125,21 +3125,28 @@
       "updatedAt": "2026-07-13",
       "notes": [
         "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main be764e7d5a2911df7fb1cc84643baf1344f9363cのREADME、book-config、公開トップ、読み方ガイド、基礎語彙、6章、実践ツールキット、ケース集、用語集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。特定書籍を必須前提とする記述はなく、通読1〜1.5時間は週単位の標準計画ではないため学習関係は空、estimatedWeeksはnullとした。",
-        "itdojp/negotiation-for-engineers-book#111 / PR #112でUX flags、旧repository slug、latent HTML typoを修正した。専用troubleshooting flowと図表索引は公開実体がないためfalseとし、Profile B必須module 2件はportal #239で追跡する。固定SHAでnpm test、Jekyll build、full audit 0、Pages top / glossaryを確認し、whatwg-encoding deprecationはsource #113へ分離した。"
+        "2026-07-13のsource Issue #114 / PR #115で、症状→確認→行動→停止・エスカレーション→記録を選ぶ専用交渉troubleshooting flowと、公開Mermaid図4件のexact図版索引、reader-facing導線、flag/route/page/inventory/anchor回帰検査を実装した。source final mainは3f1264340c526b44f883c8032febc41e8da60fa6、PR review completenessはunresolved 0、main QA・internal links・Pagesと公開routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。whatwg-encoding warningはsource #113で別追跡する。"
       ],
       "sourceRefs": [
-        "https://github.com/itdojp/negotiation-for-engineers-book/blob/be764e7d5a2911df7fb1cc84643baf1344f9363c/README.md",
-        "https://github.com/itdojp/negotiation-for-engineers-book/blob/be764e7d5a2911df7fb1cc84643baf1344f9363c/book-config.json",
-        "https://github.com/itdojp/negotiation-for-engineers-book/blob/be764e7d5a2911df7fb1cc84643baf1344f9363c/docs/index.md",
-        "https://github.com/itdojp/negotiation-for-engineers-book/blob/be764e7d5a2911df7fb1cc84643baf1344f9363c/docs/glossary/index.md",
-        "https://github.com/itdojp/negotiation-for-engineers-book/blob/be764e7d5a2911df7fb1cc84643baf1344f9363c/docs/appendices/toolkit/index.md",
+        "https://github.com/itdojp/negotiation-for-engineers-book/blob/3f1264340c526b44f883c8032febc41e8da60fa6/README.md",
+        "https://github.com/itdojp/negotiation-for-engineers-book/blob/3f1264340c526b44f883c8032febc41e8da60fa6/book-config.json",
+        "https://github.com/itdojp/negotiation-for-engineers-book/blob/3f1264340c526b44f883c8032febc41e8da60fa6/docs/index.md",
+        "https://github.com/itdojp/negotiation-for-engineers-book/blob/3f1264340c526b44f883c8032febc41e8da60fa6/docs/glossary/index.md",
+        "https://github.com/itdojp/negotiation-for-engineers-book/blob/3f1264340c526b44f883c8032febc41e8da60fa6/docs/appendices/toolkit/index.md",
         "https://itdojp.github.io/negotiation-for-engineers-book/",
         "https://itdojp.github.io/negotiation-for-engineers-book/glossary/",
         "https://itdojp.github.io/negotiation-for-engineers-book/appendices/toolkit/",
         "https://github.com/itdojp/negotiation-for-engineers-book/issues/111",
         "https://github.com/itdojp/negotiation-for-engineers-book/pull/112",
         "https://github.com/itdojp/negotiation-for-engineers-book/issues/113",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/238"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/238",
+        "https://github.com/itdojp/negotiation-for-engineers-book/blob/3f1264340c526b44f883c8032febc41e8da60fa6/docs/appendices/troubleshooting/index.md",
+        "https://github.com/itdojp/negotiation-for-engineers-book/blob/3f1264340c526b44f883c8032febc41e8da60fa6/docs/appendices/figures/index.md",
+        "https://itdojp.github.io/negotiation-for-engineers-book/appendices/troubleshooting/",
+        "https://itdojp.github.io/negotiation-for-engineers-book/appendices/figures/",
+        "https://github.com/itdojp/negotiation-for-engineers-book/issues/114",
+        "https://github.com/itdojp/negotiation-for-engineers-book/pull/115",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/239"
       ]
     },
     {
@@ -3191,16 +3198,16 @@
       "relatedEditions": [],
       "reviewStatus": "reviewed",
       "lastReviewedAt": "2026-07-13",
-      "reviewIssue": 238,
+      "reviewIssue": 239,
       "ux": {
         "profile": "B",
         "modules": {
           "quickStart": true,
           "readingGuide": true,
           "checklistPack": true,
-          "troubleshootingFlow": false,
+          "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": false,
+          "figureIndex": true,
           "legalNotice": false,
           "glossary": false
         }
@@ -3209,15 +3216,15 @@
       "updatedAt": "2026-07-13",
       "notes": [
         "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main f3b07c4eba988a627f834744e4c8e2a96bf879a1のREADME、root / 公開book-config、トップ、Quick Start、10章、チェックリスト集、テンプレート集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。共同作業・日本語業務コミュニケーションの経験は特定書籍の前提ではなく、通読8〜12時間は週単位の標準計画ではないためprerequisitesは空、estimatedWeeksはnullとした。",
-        "公開トップの「シリーズとの接続」と各章の「次の一手」が、利害調整時はnegotiation-for-engineers-book、AI支援導入時はai-communication-bookへ進む導線を明示するためrecommendedAfterへ記録した。source #136 / PR #139でnpm audit 16件を0へ解消してroot QAをCI化し、#138 / PR #140でrootと公開UX metadataを同期した。専用troubleshooting flow / figure indexはなくProfile B必須module 2件をportal #239で追跡する。source残件は#137、#141〜#143。"
+        "2026-07-13のsource Issue #144 / PR #145で、安全・緊急度→状況整理→行動→停止・エスカレーション→記録を選ぶ専用book-wide troubleshooting flow、医療診断非代替と専門窓口の境界、公開inline SVG 20件のexact図版索引、stable fragment、src/docs同期・回帰検査を実装した。source final mainは433fcbe19a9299df07d3488a30cbb7d370176cdb、PR review completenessはunresolved 0、main QA・Pages、公開book-configと両routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。source残件#137/#141〜#143は別スコープを維持する。"
       ],
       "sourceRefs": [
-        "https://github.com/itdojp/IT-engineer-communication-book/blob/f3b07c4eba988a627f834744e4c8e2a96bf879a1/README.md",
-        "https://github.com/itdojp/IT-engineer-communication-book/blob/f3b07c4eba988a627f834744e4c8e2a96bf879a1/book-config.json",
-        "https://github.com/itdojp/IT-engineer-communication-book/blob/f3b07c4eba988a627f834744e4c8e2a96bf879a1/docs/book-config.json",
-        "https://github.com/itdojp/IT-engineer-communication-book/blob/f3b07c4eba988a627f834744e4c8e2a96bf879a1/docs/index.md",
-        "https://github.com/itdojp/IT-engineer-communication-book/blob/f3b07c4eba988a627f834744e4c8e2a96bf879a1/docs/chapter-quickstart/index.md",
-        "https://github.com/itdojp/IT-engineer-communication-book/blob/f3b07c4eba988a627f834744e4c8e2a96bf879a1/docs/appendix-01-checklists/index.md",
+        "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/README.md",
+        "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/book-config.json",
+        "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/docs/book-config.json",
+        "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/docs/index.md",
+        "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/docs/chapter-quickstart/index.md",
+        "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/docs/appendix-01-checklists/index.md",
         "https://itdojp.github.io/IT-engineer-communication-book/",
         "https://itdojp.github.io/IT-engineer-communication-book/book-config.json",
         "https://itdojp.github.io/IT-engineer-communication-book/chapter-quickstart/",
@@ -3226,7 +3233,14 @@
         "https://github.com/itdojp/IT-engineer-communication-book/pull/139",
         "https://github.com/itdojp/IT-engineer-communication-book/issues/138",
         "https://github.com/itdojp/IT-engineer-communication-book/pull/140",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/238"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/238",
+        "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/docs/appendix-05-troubleshooting-flow/index.md",
+        "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/docs/appendix-06-figure-index/index.md",
+        "https://itdojp.github.io/IT-engineer-communication-book/appendix-05-troubleshooting-flow/",
+        "https://itdojp.github.io/IT-engineer-communication-book/appendix-06-figure-index/",
+        "https://github.com/itdojp/IT-engineer-communication-book/issues/144",
+        "https://github.com/itdojp/IT-engineer-communication-book/pull/145",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/239"
       ]
     },
     {

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -3125,7 +3125,7 @@
       "updatedAt": "2026-07-13",
       "notes": [
         "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main be764e7d5a2911df7fb1cc84643baf1344f9363cのREADME、book-config、公開トップ、読み方ガイド、基礎語彙、6章、実践ツールキット、ケース集、用語集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。特定書籍を必須前提とする記述はなく、通読1〜1.5時間は週単位の標準計画ではないため学習関係は空、estimatedWeeksはnullとした。",
-        "2026-07-13のsource Issue #114 / PR #115で、症状→確認→行動→停止・エスカレーション→記録を選ぶ専用交渉troubleshooting flowと、公開Mermaid図4件のexact図版索引、reader-facing導線、flag/route/page/inventory/anchor回帰検査を実装した。source final mainは3f1264340c526b44f883c8032febc41e8da60fa6、PR review completenessはunresolved 0、main QA・internal links・Pagesと公開routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。whatwg-encoding warningはsource #113で別追跡する。"
+        "2026-07-13のitdojp/negotiation-for-engineers-book#114 / PR #115で、症状→確認→行動→停止・エスカレーション→記録を選ぶ専用交渉troubleshooting flowと、公開Mermaid図4件のexact図版索引、reader-facing導線、flag/route/page/inventory/anchor回帰検査を実装した。source final mainは3f1264340c526b44f883c8032febc41e8da60fa6、PR review completenessはunresolved 0、main QA・internal links・Pagesと公開routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。whatwg-encoding warningはitdojp/negotiation-for-engineers-book#113で別追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/negotiation-for-engineers-book/blob/3f1264340c526b44f883c8032febc41e8da60fa6/README.md",
@@ -3216,7 +3216,7 @@
       "updatedAt": "2026-07-13",
       "notes": [
         "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main f3b07c4eba988a627f834744e4c8e2a96bf879a1のREADME、root / 公開book-config、トップ、Quick Start、10章、チェックリスト集、テンプレート集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。共同作業・日本語業務コミュニケーションの経験は特定書籍の前提ではなく、通読8〜12時間は週単位の標準計画ではないためprerequisitesは空、estimatedWeeksはnullとした。",
-        "2026-07-13のsource Issue #144 / PR #145で、安全・緊急度→状況整理→行動→停止・エスカレーション→記録を選ぶ専用book-wide troubleshooting flow、医療診断非代替と専門窓口の境界、公開inline SVG 20件のexact図版索引、stable fragment、src/docs同期・回帰検査を実装した。source final mainは433fcbe19a9299df07d3488a30cbb7d370176cdb、PR review completenessはunresolved 0、main QA・Pages、公開book-configと両routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。source残件#137/#141〜#143は別スコープを維持する。"
+        "2026-07-13のitdojp/IT-engineer-communication-book#144 / PR #145で、安全・緊急度→状況整理→行動→停止・エスカレーション→記録を選ぶ専用book-wide troubleshooting flow、医療診断非代替と専門窓口の境界、公開inline SVG 20件のexact図版索引、stable fragment、src/docs同期・回帰検査を実装した。source final mainは433fcbe19a9299df07d3488a30cbb7d370176cdb、PR review completenessはunresolved 0、main QA・Pages、公開book-configと両routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。source側の残件itdojp/IT-engineer-communication-book#137、#141〜#143は別スコープを維持する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/IT-engineer-communication-book/blob/433fcbe19a9299df07d3488a30cbb7d370176cdb/README.md",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -347,13 +347,13 @@
         "quickStart": true,
         "readingGuide": true,
         "checklistPack": true,
-        "troubleshootingFlow": false,
+        "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": false,
+        "figureIndex": true,
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main f3b07c4eba988a627f834744e4c8e2a96bf879a1のREADME、root / 公開book-config、トップ、Quick Start、10章、チェックリスト集、テンプレート集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。共同作業・日本語業務コミュニケーションの経験は特定書籍の前提ではなく、通読8〜12時間は週単位の標準計画ではないためprerequisitesは空、estimatedWeeksはnullとした。 / 公開トップの「シリーズとの接続」と各章の「次の一手」が、利害調整時はnegotiation-for-engineers-book、AI支援導入時はai-communication-bookへ進む導線を明示するためrecommendedAfterへ記録した。source #136 / PR #139でnpm audit 16件を0へ解消してroot QAをCI化し、#138 / PR #140でrootと公開UX metadataを同期した。専用troubleshooting flow / figure indexはなくProfile B必須module 2件をportal #239で追跡する。source残件は#137、#141〜#143。"
+      "notes": "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main f3b07c4eba988a627f834744e4c8e2a96bf879a1のREADME、root / 公開book-config、トップ、Quick Start、10章、チェックリスト集、テンプレート集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。共同作業・日本語業務コミュニケーションの経験は特定書籍の前提ではなく、通読8〜12時間は週単位の標準計画ではないためprerequisitesは空、estimatedWeeksはnullとした。 / 2026-07-13のsource Issue #144 / PR #145で、安全・緊急度→状況整理→行動→停止・エスカレーション→記録を選ぶ専用book-wide troubleshooting flow、医療診断非代替と専門窓口の境界、公開inline SVG 20件のexact図版索引、stable fragment、src/docs同期・回帰検査を実装した。source final mainは433fcbe19a9299df07d3488a30cbb7d370176cdb、PR review completenessはunresolved 0、main QA・Pages、公開book-configと両routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。source残件#137/#141〜#143は別スコープを維持する。"
     },
     "IT-infra-book": {
       "repo": "itdojp/IT-infra-book",
@@ -507,13 +507,13 @@
         "quickStart": false,
         "readingGuide": true,
         "checklistPack": true,
-        "troubleshootingFlow": false,
+        "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": false,
+        "figureIndex": true,
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main be764e7d5a2911df7fb1cc84643baf1344f9363cのREADME、book-config、公開トップ、読み方ガイド、基礎語彙、6章、実践ツールキット、ケース集、用語集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。特定書籍を必須前提とする記述はなく、通読1〜1.5時間は週単位の標準計画ではないため学習関係は空、estimatedWeeksはnullとした。 / itdojp/negotiation-for-engineers-book#111 / PR #112でUX flags、旧repository slug、latent HTML typoを修正した。専用troubleshooting flowと図表索引は公開実体がないためfalseとし、Profile B必須module 2件はportal #239で追跡する。固定SHAでnpm test、Jekyll build、full audit 0、Pages top / glossaryを確認し、whatwg-encoding deprecationはsource #113へ分離した。"
+      "notes": "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main be764e7d5a2911df7fb1cc84643baf1344f9363cのREADME、book-config、公開トップ、読み方ガイド、基礎語彙、6章、実践ツールキット、ケース集、用語集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。特定書籍を必須前提とする記述はなく、通読1〜1.5時間は週単位の標準計画ではないため学習関係は空、estimatedWeeksはnullとした。 / 2026-07-13のsource Issue #114 / PR #115で、症状→確認→行動→停止・エスカレーション→記録を選ぶ専用交渉troubleshooting flowと、公開Mermaid図4件のexact図版索引、reader-facing導線、flag/route/page/inventory/anchor回帰検査を実装した。source final mainは3f1264340c526b44f883c8032febc41e8da60fa6、PR review completenessはunresolved 0、main QA・internal links・Pagesと公開routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。whatwg-encoding warningはsource #113で別追跡する。"
     },
     "pentest-learning-book": {
       "repo": "itdojp/pentest-learning-book",

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -353,7 +353,7 @@
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main f3b07c4eba988a627f834744e4c8e2a96bf879a1のREADME、root / 公開book-config、トップ、Quick Start、10章、チェックリスト集、テンプレート集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。共同作業・日本語業務コミュニケーションの経験は特定書籍の前提ではなく、通読8〜12時間は週単位の標準計画ではないためprerequisitesは空、estimatedWeeksはnullとした。 / 2026-07-13のsource Issue #144 / PR #145で、安全・緊急度→状況整理→行動→停止・エスカレーション→記録を選ぶ専用book-wide troubleshooting flow、医療診断非代替と専門窓口の境界、公開inline SVG 20件のexact図版索引、stable fragment、src/docs同期・回帰検査を実装した。source final mainは433fcbe19a9299df07d3488a30cbb7d370176cdb、PR review completenessはunresolved 0、main QA・Pages、公開book-configと両routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。source残件#137/#141〜#143は別スコープを維持する。"
+      "notes": "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main f3b07c4eba988a627f834744e4c8e2a96bf879a1のREADME、root / 公開book-config、トップ、Quick Start、10章、チェックリスト集、テンプレート集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。共同作業・日本語業務コミュニケーションの経験は特定書籍の前提ではなく、通読8〜12時間は週単位の標準計画ではないためprerequisitesは空、estimatedWeeksはnullとした。 / 2026-07-13のitdojp/IT-engineer-communication-book#144 / PR #145で、安全・緊急度→状況整理→行動→停止・エスカレーション→記録を選ぶ専用book-wide troubleshooting flow、医療診断非代替と専門窓口の境界、公開inline SVG 20件のexact図版索引、stable fragment、src/docs同期・回帰検査を実装した。source final mainは433fcbe19a9299df07d3488a30cbb7d370176cdb、PR review completenessはunresolved 0、main QA・Pages、公開book-configと両routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。source側の残件itdojp/IT-engineer-communication-book#137、#141〜#143は別スコープを維持する。"
     },
     "IT-infra-book": {
       "repo": "itdojp/IT-infra-book",
@@ -513,7 +513,7 @@
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main be764e7d5a2911df7fb1cc84643baf1344f9363cのREADME、book-config、公開トップ、読み方ガイド、基礎語彙、6章、実践ツールキット、ケース集、用語集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。特定書籍を必須前提とする記述はなく、通読1〜1.5時間は週単位の標準計画ではないため学習関係は空、estimatedWeeksはnullとした。 / 2026-07-13のsource Issue #114 / PR #115で、症状→確認→行動→停止・エスカレーション→記録を選ぶ専用交渉troubleshooting flowと、公開Mermaid図4件のexact図版索引、reader-facing導線、flag/route/page/inventory/anchor回帰検査を実装した。source final mainは3f1264340c526b44f883c8032febc41e8da60fa6、PR review completenessはunresolved 0、main QA・internal links・Pagesと公開routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。whatwg-encoding warningはsource #113で別追跡する。"
+      "notes": "2026-07-13のmetadata監査itdojp/it-engineer-knowledge-architecture#238で、source main be764e7d5a2911df7fb1cc84643baf1344f9363cのREADME、book-config、公開トップ、読み方ガイド、基礎語彙、6章、実践ツールキット、ケース集、用語集、QAと公開Pagesを照合し、全レベル、対象読者、Profile Bを確定した。特定書籍を必須前提とする記述はなく、通読1〜1.5時間は週単位の標準計画ではないため学習関係は空、estimatedWeeksはnullとした。 / 2026-07-13のitdojp/negotiation-for-engineers-book#114 / PR #115で、症状→確認→行動→停止・エスカレーション→記録を選ぶ専用交渉troubleshooting flowと、公開Mermaid図4件のexact図版索引、reader-facing導線、flag/route/page/inventory/anchor回帰検査を実装した。source final mainは3f1264340c526b44f883c8032febc41e8da60fa6、PR review completenessはunresolved 0、main QA・internal links・Pagesと公開routeを確認済み。troubleshootingFlow=true / figureIndex=trueへ更新し、Profile B必須module debtを解消した。whatwg-encoding warningはitdojp/negotiation-for-engineers-book#113で別追跡する。"
     },
     "pentest-learning-book": {
       "repo": "itdojp/pentest-learning-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -138,8 +138,8 @@
       "bookIds": []
     },
     "missingRequiredUxModules": {
-      "count": 37,
-      "bookCount": 26,
+      "count": 33,
+      "bookCount": 24,
       "books": [
         {
           "id": "GitHub-AgentOps-book",
@@ -150,24 +150,6 @@
               "reason": "実ファイルと公開Pages監査で専用の図表索引が未実装であることを確認済み。章内図表を索引として扱わず、根拠のないtrueへの変更は行わない。",
               "evidenceIssue": 226,
               "trackingIssue": 227
-            }
-          ]
-        },
-        {
-          "id": "IT-engineer-communication-book",
-          "profile": "B",
-          "missingModules": [
-            {
-              "module": "figureIndex",
-              "reason": "公開Pagesに専用図表索引とreader-facing navigationがない。トップの図から読む案内や章内図版を独立した図表索引として代用せずfalseを維持する。",
-              "evidenceIssue": 238,
-              "trackingIssue": 239
-            },
-            {
-              "module": "troubleshootingFlow",
-              "reason": "公開Pagesに専用トラブルシューティングフローとreader-facing navigationがない。章内の失敗例、デバッグ手順、ストレス対処を専用moduleとして代用せずfalseを維持する。",
-              "evidenceIssue": 238,
-              "trackingIssue": 239
             }
           ]
         },
@@ -436,24 +418,6 @@
           ]
         },
         {
-          "id": "negotiation-for-engineers-book",
-          "profile": "B",
-          "missingModules": [
-            {
-              "module": "figureIndex",
-              "reason": "公開Pagesに専用図表索引とreader-facing navigationがない。個別図版、目次、テンプレート一覧を図表索引として代用せずfalseを維持する。",
-              "evidenceIssue": 238,
-              "trackingIssue": 239
-            },
-            {
-              "module": "troubleshootingFlow",
-              "reason": "公開Pagesに専用トラブルシューティングフローとreader-facing navigationがない。章内のケース、感情デバッグ、失敗時の立て直し説明を専用moduleとして代用せずfalseを維持する。",
-              "evidenceIssue": 238,
-              "trackingIssue": 239
-            }
-          ]
-        },
-        {
           "id": "pentest-learning-book",
           "profile": "B",
           "missingModules": [
@@ -528,8 +492,8 @@
   },
   "gates": {
     "requiredUxModuleDebt": {
-      "baselineCount": 37,
-      "currentCount": 37,
+      "baselineCount": 33,
+      "currentCount": 33,
       "unapprovedCount": 0,
       "unapproved": [],
       "staleBaselineCount": 0,

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -264,38 +264,6 @@
       "reason": "公開Pagesに専用用語集とreader-facing導線がない。本文内の用語統一方針を用語集の実体として代用せずfalseを維持する。",
       "evidenceIssue": 235,
       "trackingIssue": 236
-    },
-    {
-      "bookId": "negotiation-for-engineers-book",
-      "profile": "B",
-      "module": "troubleshootingFlow",
-      "reason": "公開Pagesに専用トラブルシューティングフローとreader-facing navigationがない。章内のケース、感情デバッグ、失敗時の立て直し説明を専用moduleとして代用せずfalseを維持する。",
-      "evidenceIssue": 238,
-      "trackingIssue": 239
-    },
-    {
-      "bookId": "negotiation-for-engineers-book",
-      "profile": "B",
-      "module": "figureIndex",
-      "reason": "公開Pagesに専用図表索引とreader-facing navigationがない。個別図版、目次、テンプレート一覧を図表索引として代用せずfalseを維持する。",
-      "evidenceIssue": 238,
-      "trackingIssue": 239
-    },
-    {
-      "bookId": "IT-engineer-communication-book",
-      "profile": "B",
-      "module": "troubleshootingFlow",
-      "reason": "公開Pagesに専用トラブルシューティングフローとreader-facing navigationがない。章内の失敗例、デバッグ手順、ストレス対処を専用moduleとして代用せずfalseを維持する。",
-      "evidenceIssue": 238,
-      "trackingIssue": 239
-    },
-    {
-      "bookId": "IT-engineer-communication-book",
-      "profile": "B",
-      "module": "figureIndex",
-      "reason": "公開Pagesに専用図表索引とreader-facing navigationがない。トップの図から読む案内や章内図版を独立した図表索引として代用せずfalseを維持する。",
-      "evidenceIssue": 238,
-      "trackingIssue": 239
     }
   ]
 }


### PR DESCRIPTION
## 概要

Portal Issue #239 で追跡している2冊の Profile B 必須 UX module 4件について、source側の実装・review・CI・Pages・公開smoke完了後にcatalogを同期します。

- `negotiation-for-engineers-book`
  - source Issue #114 / PR #115
  - final main `3f1264340c526b44f883c8032febc41e8da60fa6`
  - troubleshooting flow / figure index を公開済み
- `IT-engineer-communication-book`
  - source Issue #144 / PR #145
  - final main `433fcbe19a9299df07d3488a30cbb7d370176cdb`
  - troubleshooting flow / figure index を公開済み

## 変更

- 両書籍の `troubleshootingFlow` / `figureIndex` を `true` に更新
- sourceの固定SHA、Issue/PR、公開routeを証跡として追加
- #238で追加したbaseline entry 4件を削除
- registry / debt reportを再生成
- required UX module debt: 37 → 33
- 対象書籍数: 26 → 24
- baseline/current: 33/33
- unapproved/stale: 0/0

## 検証

- `npm ci`
- `npm run generate`
- `npm run verify`（E2E 45件を含む）
- `npm audit --audit-level=moderate`（0 vulnerabilities）
- `git diff --check`
- source final main SHA / 公開4 routeの再確認
- 独立reviewer: major/moderate指摘なし

Closes #239
