### PR TITLE
catalog: Kubernetes 3冊の図表索引debtを解消する

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -1295,8 +1295,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
-      "reviewIssue": 214,
+      "lastReviewedAt": "2026-07-13",
+      "reviewIssue": 215,
       "ux": {
         "profile": "B",
         "modules": {
@@ -1305,15 +1305,16 @@
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": false,
+          "figureIndex": true,
           "legalNotice": false,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-12",
+      "updatedAt": "2026-07-13",
       "notes": [
-        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。itdojp/it-engineer-knowledge-architecture#216で、コンテナ基礎を先に学ぶcanonical pathはpodman-bookから本書へ進む順へ補正した。一方、本文・あとがきのPodman本は基礎を後から補う任意参照として有効なため、recommendedAfterはkubernetes-cluster-ops-bookとpodman-bookを維持する。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。itdojp/it-engineer-knowledge-architecture#216で、コンテナ基礎を先に学ぶcanonical pathはpodman-bookから本書へ進む順へ補正した。一方、本文・あとがきのPodman本は基礎を後から補う任意参照として有効なため、recommendedAfterはkubernetes-cluster-ops-bookとpodman-bookを維持する。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。",
+        "2026-07-13にitdojp/it-engineer-knowledge-architecture#215、source Issue itdojp/kubernetes-basics-book#36、source PR itdojp/kubernetes-basics-book#37で公開本文から参照されるPNG exact 12件を収録した付録Eの専用図表索引、本文stable anchor、top/sidebar/prev-next導線、回帰gateを実装。source main 3e427f86a08efaf8168c2faed9ce74384cbecb7a、Book QA、Pages、公開索引から本文anchorへの本番疎通を確認し、figureIndex=trueへ更新した。既存のスクリーンショット取得Issueは別スコープを維持する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/kubernetes-basics-book/blob/8e02d0298fc9a9bb960b0bb1acec5d5fea259522/README.md",
@@ -1332,7 +1333,16 @@
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214#issuecomment-4950006573",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216#issuecomment-4950171069"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216#issuecomment-4950171069",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/3e427f86a08efaf8168c2faed9ce74384cbecb7a/book-config.json",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/3e427f86a08efaf8168c2faed9ce74384cbecb7a/docs/index.md",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/3e427f86a08efaf8168c2faed9ce74384cbecb7a/docs/_data/navigation.yml",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/3e427f86a08efaf8168c2faed9ce74384cbecb7a/docs/appendices/appendix-e/index.md",
+        "https://github.com/itdojp/kubernetes-basics-book/issues/36",
+        "https://github.com/itdojp/kubernetes-basics-book/pull/37",
+        "https://itdojp.github.io/kubernetes-basics-book/appendices/appendix-e/",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215#issuecomment-4955297700",
+        "https://github.com/itdojp/kubernetes-basics-book/blob/3e427f86a08efaf8168c2faed9ce74384cbecb7a/scripts/check-figure-index.js"
       ]
     },
     {
@@ -1386,8 +1396,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
-      "reviewIssue": 214,
+      "lastReviewedAt": "2026-07-13",
+      "reviewIssue": 215,
       "ux": {
         "profile": "B",
         "modules": {
@@ -1396,15 +1406,16 @@
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": false,
+          "figureIndex": true,
           "legalNotice": false,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-12",
+      "updatedAt": "2026-07-13",
       "notes": [
-        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-cluster-ops-book#34で、source main b1cda610e6c006589093b5cce1b5d7a6f63b6474のREADME、両config、公開トップ、導入、チェックリスト、Runbook、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。本文で案内されたkubernetes-basics-bookを前提とする。itdojp/it-engineer-knowledge-architecture#216では、kubernetes-proxmox-to-cloud-bookを必須前提ではない線形パス上の発展先として維持した。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-cluster-ops-book#34で、source main b1cda610e6c006589093b5cce1b5d7a6f63b6474のREADME、両config、公開トップ、導入、チェックリスト、Runbook、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。本文で案内されたkubernetes-basics-bookを前提とする。itdojp/it-engineer-knowledge-architecture#216では、kubernetes-proxmox-to-cloud-bookを必須前提ではない線形パス上の発展先として維持した。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。",
+        "2026-07-13にitdojp/it-engineer-knowledge-architecture#215、source Issue itdojp/kubernetes-cluster-ops-book#36、source PR itdojp/kubernetes-cluster-ops-book#37で公開本文から参照されるPNG exact 2件を収録した付録Dの専用図表索引、本文stable anchor、top/sidebar/prev/next導線、回帰gateを実装。source main d9a9a0abf67a95cc5ace2df1932755c4dd38f928、Book QA、Pages、公開索引から本文anchorへの本番疎通を確認し、figureIndex=trueへ更新した。既存のスクリーンショット取得Issueは別スコープを維持する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/b1cda610e6c006589093b5cce1b5d7a6f63b6474/README.md",
@@ -1423,7 +1434,16 @@
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214#issuecomment-4950006573",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216#issuecomment-4950171069"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216#issuecomment-4950171069",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/d9a9a0abf67a95cc5ace2df1932755c4dd38f928/book-config.json",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/d9a9a0abf67a95cc5ace2df1932755c4dd38f928/docs/index.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/d9a9a0abf67a95cc5ace2df1932755c4dd38f928/docs/_data/navigation.yml",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/d9a9a0abf67a95cc5ace2df1932755c4dd38f928/docs/appendices/appendix-d/index.md",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/issues/36",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/pull/37",
+        "https://itdojp.github.io/kubernetes-cluster-ops-book/appendices/appendix-d/",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215#issuecomment-4955297700",
+        "https://github.com/itdojp/kubernetes-cluster-ops-book/blob/d9a9a0abf67a95cc5ace2df1932755c4dd38f928/scripts/check-figure-index.js"
       ]
     },
     {
@@ -1473,8 +1493,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
-      "reviewIssue": 214,
+      "lastReviewedAt": "2026-07-13",
+      "reviewIssue": 215,
       "ux": {
         "profile": "B",
         "modules": {
@@ -1483,15 +1503,16 @@
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": false,
+          "figureIndex": true,
           "legalNotice": true,
           "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-12",
+      "updatedAt": "2026-07-13",
       "notes": [
-        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-proxmox-to-cloud-book#39で、source main d445b408e506551923bb3c1aa38d383ba9961e24のREADME、book-config、公開トップ、Quick Start、読み方、ライセンスFAQ、チェックリスト、トラブルシュート、用語集を照合し、対象読者、Profile B、modulesを確定。1〜3週間の範囲表記はcatalogの単一整数へ任意転記せずestimatedWeeksはnull。必須前提は追加しない。itdojp/it-engineer-knowledge-architecture#216でcloud-container線形パスの発展的な終点へ補正し、根拠のある次読書籍がないためrecommendedAfterは空を維持する。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
+        "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-proxmox-to-cloud-book#39で、source main d445b408e506551923bb3c1aa38d383ba9961e24のREADME、book-config、公開トップ、Quick Start、読み方、ライセンスFAQ、チェックリスト、トラブルシュート、用語集を照合し、対象読者、Profile B、modulesを確定。1〜3週間の範囲表記はcatalogの単一整数へ任意転記せずestimatedWeeksはnull。必須前提は追加しない。itdojp/it-engineer-knowledge-architecture#216でcloud-container線形パスの発展的な終点へ補正し、根拠のある次読書籍がないためrecommendedAfterは空を維持する。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。",
+        "2026-07-13にitdojp/it-engineer-knowledge-architecture#215、source Issue itdojp/kubernetes-proxmox-to-cloud-book#41、source PR itdojp/kubernetes-proxmox-to-cloud-book#43で既存Mermaid概念図 exact 5件をaccessibility情報付き静的SVGへ変換し、専用図表索引、本文stable anchor、top/sidebar/prev/next導線、回帰gateを実装。source main acf583079eaf0257bf87c64a811c56155a5ab2c8、Book QA、Pages、公開索引から本文anchorへの本番疎通を確認し、figureIndex=trueへ更新した。既存のスクリーンショット取得Issueは別スコープを維持する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/d445b408e506551923bb3c1aa38d383ba9961e24/README.md",
@@ -1512,7 +1533,16 @@
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/214#issuecomment-4950006573",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216#issuecomment-4950171069"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/216#issuecomment-4950171069",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/acf583079eaf0257bf87c64a811c56155a5ab2c8/book-config.json",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/acf583079eaf0257bf87c64a811c56155a5ab2c8/docs/index.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/acf583079eaf0257bf87c64a811c56155a5ab2c8/docs/_data/navigation.yml",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/acf583079eaf0257bf87c64a811c56155a5ab2c8/docs/appendices/figure-index/index.md",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/issues/41",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/pull/43",
+        "https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/appendices/figure-index/",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/215#issuecomment-4955297700",
+        "https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/blob/acf583079eaf0257bf87c64a811c56155a5ab2c8/scripts/check-metadata-consistency.js"
       ]
     },
     {

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -429,11 +429,11 @@
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": false,
+        "figureIndex": true,
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。itdojp/it-engineer-knowledge-architecture#216で、コンテナ基礎を先に学ぶcanonical pathはpodman-bookから本書へ進む順へ補正した。一方、本文・あとがきのPodman本は基礎を後から補う任意参照として有効なため、recommendedAfterはkubernetes-cluster-ops-bookとpodman-bookを維持する。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-basics-book#34で、source main 8e02d0298fc9a9bb960b0bb1acec5d5fea259522のREADME、両config、公開トップ、導入、チェックリスト、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。itdojp/it-engineer-knowledge-architecture#216で、コンテナ基礎を先に学ぶcanonical pathはpodman-bookから本書へ進む順へ補正した。一方、本文・あとがきのPodman本は基礎を後から補う任意参照として有効なため、recommendedAfterはkubernetes-cluster-ops-bookとpodman-bookを維持する。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。 / 2026-07-13にitdojp/it-engineer-knowledge-architecture#215、source Issue itdojp/kubernetes-basics-book#36、source PR itdojp/kubernetes-basics-book#37で公開本文から参照されるPNG exact 12件を収録した付録Eの専用図表索引、本文stable anchor、top/sidebar/prev-next導線、回帰gateを実装。source main 3e427f86a08efaf8168c2faed9ce74384cbecb7a、Book QA、Pages、公開索引から本文anchorへの本番疎通を確認し、figureIndex=trueへ更新した。既存のスクリーンショット取得Issueは別スコープを維持する。"
     },
     "kubernetes-cluster-ops-book": {
       "repo": "itdojp/kubernetes-cluster-ops-book",
@@ -445,11 +445,11 @@
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": false,
+        "figureIndex": true,
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-cluster-ops-book#34で、source main b1cda610e6c006589093b5cce1b5d7a6f63b6474のREADME、両config、公開トップ、導入、チェックリスト、Runbook、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。本文で案内されたkubernetes-basics-bookを前提とする。itdojp/it-engineer-knowledge-architecture#216では、kubernetes-proxmox-to-cloud-bookを必須前提ではない線形パス上の発展先として維持した。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-cluster-ops-book#34で、source main b1cda610e6c006589093b5cce1b5d7a6f63b6474のREADME、両config、公開トップ、導入、チェックリスト、Runbook、トラブルシュート導線を照合し、対象読者、Profile B、modulesを確定。本文で案内されたkubernetes-basics-bookを前提とする。itdojp/it-engineer-knowledge-architecture#216では、kubernetes-proxmox-to-cloud-bookを必須前提ではない線形パス上の発展先として維持した。週数根拠がないためestimatedWeeksはnull。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。 / 2026-07-13にitdojp/it-engineer-knowledge-architecture#215、source Issue itdojp/kubernetes-cluster-ops-book#36、source PR itdojp/kubernetes-cluster-ops-book#37で公開本文から参照されるPNG exact 2件を収録した付録Dの専用図表索引、本文stable anchor、top/sidebar/prev/next導線、回帰gateを実装。source main d9a9a0abf67a95cc5ace2df1932755c4dd38f928、Book QA、Pages、公開索引から本文anchorへの本番疎通を確認し、figureIndex=trueへ更新した。既存のスクリーンショット取得Issueは別スコープを維持する。"
     },
     "kubernetes-proxmox-to-cloud-book": {
       "repo": "itdojp/kubernetes-proxmox-to-cloud-book",
@@ -461,11 +461,11 @@
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": false,
+        "figureIndex": true,
         "legalNotice": true,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-proxmox-to-cloud-book#39で、source main d445b408e506551923bb3c1aa38d383ba9961e24のREADME、book-config、公開トップ、Quick Start、読み方、ライセンスFAQ、チェックリスト、トラブルシュート、用語集を照合し、対象読者、Profile B、modulesを確定。1〜3週間の範囲表記はcatalogの単一整数へ任意転記せずestimatedWeeksはnull。必須前提は追加しない。itdojp/it-engineer-knowledge-architecture#216でcloud-container線形パスの発展的な終点へ補正し、根拠のある次読書籍がないためrecommendedAfterは空を維持する。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。"
+      "notes": "2026-07-12のmetadata監査itdojp/it-engineer-knowledge-architecture#214とitdojp/kubernetes-proxmox-to-cloud-book#39で、source main d445b408e506551923bb3c1aa38d383ba9961e24のREADME、book-config、公開トップ、Quick Start、読み方、ライセンスFAQ、チェックリスト、トラブルシュート、用語集を照合し、対象読者、Profile B、modulesを確定。1〜3週間の範囲表記はcatalogの単一整数へ任意転記せずestimatedWeeksはnull。必須前提は追加しない。itdojp/it-engineer-knowledge-architecture#216でcloud-container線形パスの発展的な終点へ補正し、根拠のある次読書籍がないためrecommendedAfterは空を維持する。専用図表索引の実装はitdojp/it-engineer-knowledge-architecture#215で追跡する。 / 2026-07-13にitdojp/it-engineer-knowledge-architecture#215、source Issue itdojp/kubernetes-proxmox-to-cloud-book#41、source PR itdojp/kubernetes-proxmox-to-cloud-book#43で既存Mermaid概念図 exact 5件をaccessibility情報付き静的SVGへ変換し、専用図表索引、本文stable anchor、top/sidebar/prev/next導線、回帰gateを実装。source main acf583079eaf0257bf87c64a811c56155a5ab2c8、Book QA、Pages、公開索引から本文anchorへの本番疎通を確認し、figureIndex=trueへ更新した。既存のスクリーンショット取得Issueは別スコープを維持する。"
     },
     "linux-infra-textbook2": {
       "repo": "itdojp/linux-infra-textbook2",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -138,8 +138,8 @@
       "bookIds": []
     },
     "missingRequiredUxModules": {
-      "count": 29,
-      "bookCount": 22,
+      "count": 26,
+      "bookCount": 19,
       "books": [
         {
           "id": "GitHub-AgentOps-book",
@@ -334,42 +334,6 @@
           ]
         },
         {
-          "id": "kubernetes-basics-book",
-          "profile": "B",
-          "missingModules": [
-            {
-              "module": "figureIndex",
-              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-              "evidenceIssue": 214,
-              "trackingIssue": 215
-            }
-          ]
-        },
-        {
-          "id": "kubernetes-cluster-ops-book",
-          "profile": "B",
-          "missingModules": [
-            {
-              "module": "figureIndex",
-              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-              "evidenceIssue": 214,
-              "trackingIssue": 215
-            }
-          ]
-        },
-        {
-          "id": "kubernetes-proxmox-to-cloud-book",
-          "profile": "B",
-          "missingModules": [
-            {
-              "module": "figureIndex",
-              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-              "evidenceIssue": 214,
-              "trackingIssue": 215
-            }
-          ]
-        },
-        {
           "id": "linux-infra-textbook2",
           "profile": "A",
           "missingModules": [
@@ -456,8 +420,8 @@
   },
   "gates": {
     "requiredUxModuleDebt": {
-      "baselineCount": 29,
-      "currentCount": 29,
+      "baselineCount": 26,
+      "currentCount": 26,
       "unapprovedCount": 0,
       "unapproved": [],
       "staleBaselineCount": 0,

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -74,30 +74,6 @@
       "trackingIssue": 210
     },
     {
-      "bookId": "kubernetes-basics-book",
-      "profile": "B",
-      "module": "figureIndex",
-      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-      "evidenceIssue": 214,
-      "trackingIssue": 215
-    },
-    {
-      "bookId": "kubernetes-cluster-ops-book",
-      "profile": "B",
-      "module": "figureIndex",
-      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-      "evidenceIssue": 214,
-      "trackingIssue": 215
-    },
-    {
-      "bookId": "kubernetes-proxmox-to-cloud-book",
-      "profile": "B",
-      "module": "figureIndex",
-      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-      "evidenceIssue": 214,
-      "trackingIssue": 215
-    },
-    {
       "bookId": "linux-infra-textbook2",
       "profile": "A",
       "module": "quickStart",


### PR DESCRIPTION
## 概要

Kubernetes 3冊で実装・公開済みとなった専用図表索引をcatalogへ反映し、Issue #215のrequired UX debtを解消します。

## 変更

- `kubernetes-basics-book`: `figureIndex=true`、付録E（公開PNG exact 12件）の固定main・公開証跡を追加
- `kubernetes-cluster-ops-book`: `figureIndex=true`、付録D（公開PNG exact 2件）の固定main・公開証跡を追加
- `kubernetes-proxmox-to-cloud-book`: `figureIndex=true`、静的SVG exact 5件の図表索引の固定main・公開証跡を追加
- `lastReviewedAt` / `reviewIssue` / `updatedAt` を #215 の完了監査へ更新
- debt baselineから該当3件だけを削除し、生成物を同期

## Source-side evidence

| Book | Source Issue / PR | final main | main QA / Pages | production |
|---|---|---|---|---|
| kubernetes-basics-book | itdojp/kubernetes-basics-book#36 / #37 | `3e427f86a08efaf8168c2faed9ce74384cbecb7a` | [QA](https://github.com/itdojp/kubernetes-basics-book/actions/runs/29232975370) / [Pages](https://github.com/itdojp/kubernetes-basics-book/actions/runs/29232974576) | [付録E](https://itdojp.github.io/kubernetes-basics-book/appendices/appendix-e/) |
| kubernetes-cluster-ops-book | itdojp/kubernetes-cluster-ops-book#36 / #37 | `d9a9a0abf67a95cc5ace2df1932755c4dd38f928` | [QA](https://github.com/itdojp/kubernetes-cluster-ops-book/actions/runs/29232979538) / [Pages](https://github.com/itdojp/kubernetes-cluster-ops-book/actions/runs/29232978680) | [付録D](https://itdojp.github.io/kubernetes-cluster-ops-book/appendices/appendix-d/) |
| kubernetes-proxmox-to-cloud-book | itdojp/kubernetes-proxmox-to-cloud-book#41 / #43 | `acf583079eaf0257bf87c64a811c56155a5ab2c8` | [QA](https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/actions/runs/29232983759) / [Pages](https://github.com/itdojp/kubernetes-proxmox-to-cloud-book/actions/runs/29232982970) | [図表索引](https://itdojp.github.io/kubernetes-proxmox-to-cloud-book/appendices/figure-index/) |

公開索引から本文stable anchorへの本番確認は exact 12 / 2 / 5件すべてHTTP 200です。未取得スクリーンショットと既存の別Issueは非スコープのままです。

## Debt gate

- required UX modules: `29 -> 26`
- affected books: `22 -> 19`
- baseline/current: `26 / 26`
- unapproved/stale: `0 / 0`

## 検証

- `npm audit --audit-level=high`（0 vulnerabilities）
- `npm run verify`（catalog validation、completion/debt gates、production smoke、Pages drift、Jekyll build、Playwright 45件を含み成功）
- `git diff --check`

Closes #215
