### PR TITLE
Process・Documentation・SecurityのUX debtを解消する

### DIFF
--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -342,7 +342,8 @@
         "https://github.com/itdojp/issue-driven-work-book/issues/34#issuecomment-4960265976",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250#issuecomment-4960268214",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/262"
       ]
     },
     {
@@ -434,7 +435,8 @@
         "https://github.com/itdojp/engineering-documentation-book/issues/32#issuecomment-4961041759",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250#issuecomment-4961044702",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/262"
       ]
     },
     {
@@ -526,7 +528,8 @@
         "https://github.com/itdojp/security-privacy-literacy-book/issues/37#issuecomment-4961041802",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250#issuecomment-4961044901",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/262"
       ]
     },
     {
@@ -620,7 +623,8 @@
         "https://github.com/itdojp/incident-response-basics-book/issues/36#issuecomment-4961041797",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250#issuecomment-4961045138",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/262"
       ]
     },
     {

--- a/docs/_data/catalog.json
+++ b/docs/_data/catalog.json
@@ -299,8 +299,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
-      "reviewIssue": 193,
+      "lastReviewedAt": "2026-07-14",
+      "reviewIssue": 250,
       "ux": {
         "profile": "A",
         "modules": {
@@ -311,13 +311,14 @@
           "conceptMap": false,
           "figureIndex": false,
           "legalNotice": true,
-          "glossary": false
+          "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-12",
+      "updatedAt": "2026-07-14",
       "notes": [
-        "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
+        "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。",
+        "2026-07-14にitdojp/it-engineer-knowledge-architecture#250、source Issue itdojp/issue-driven-work-book#34、source PR itdojp/issue-driven-work-book#35で、本文根拠とcanonical参照を持つexact 18用語の専用/appendices/glossary/、stable anchors/deep links、top/navigation/prev-nextとfail-closed回帰gateを実装。source main ff236e117f8570470c0b44b1e2a4954104629e6a、review completeness unresolved 0、CI、Pages、18 anchors/referencesと公開導線の本番疎通を確認し、glossary=trueへ更新した。GitHub Actions Node.js 20廃止annotationはitdojp/it-engineer-knowledge-architecture#258で別追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/issue-driven-work-book/blob/main/README.md",
@@ -330,7 +331,18 @@
         "https://github.com/itdojp/issue-driven-work-book/blob/main/LICENSE.md",
         "docs/professional-foundations.md",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/198"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/198",
+        "https://github.com/itdojp/issue-driven-work-book/blob/ff236e117f8570470c0b44b1e2a4954104629e6a/book-config.json",
+        "https://github.com/itdojp/issue-driven-work-book/blob/ff236e117f8570470c0b44b1e2a4954104629e6a/docs/appendices/glossary/index.md",
+        "https://github.com/itdojp/issue-driven-work-book/blob/ff236e117f8570470c0b44b1e2a4954104629e6a/docs/_data/navigation.yml",
+        "https://github.com/itdojp/issue-driven-work-book/blob/ff236e117f8570470c0b44b1e2a4954104629e6a/scripts/check-reader-ux.js",
+        "https://github.com/itdojp/issue-driven-work-book/issues/34",
+        "https://github.com/itdojp/issue-driven-work-book/pull/35",
+        "https://itdojp.github.io/issue-driven-work-book/appendices/glossary/",
+        "https://github.com/itdojp/issue-driven-work-book/issues/34#issuecomment-4960265976",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250#issuecomment-4960268214",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258"
       ]
     },
     {
@@ -379,8 +391,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
-      "reviewIssue": 193,
+      "lastReviewedAt": "2026-07-14",
+      "reviewIssue": 250,
       "ux": {
         "profile": "B",
         "modules": {
@@ -389,15 +401,16 @@
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": false,
+          "figureIndex": true,
           "legalNotice": false,
           "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-12",
+      "updatedAt": "2026-07-14",
       "notes": [
-        "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引は未実装。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
+        "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引がない状態を確認し、必須module debtを#250へ追跡移管した。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。",
+        "2026-07-14にitdojp/it-engineer-knowledge-architecture#250、source Issue itdojp/engineering-documentation-book#32、source PR itdojp/engineering-documentation-book#33で、公開Mermaid正本exact 5件に対応するaccessible/self-contained SVG preview、stable anchorsと相対deep linksを持つ専用/appendices/figure-index/、top/navigation/prev-nextとfail-closed/compatibility回帰gateを実装。source main 3df782481f883764ffc4f6eff0439ee0bcaded7e、review completeness unresolved 0、CI、Pages、5 entries/anchors/assetsと公開導線の本番疎通を確認し、figureIndex=trueへ更新した。GitHub Actions Node.js 20廃止annotationはitdojp/it-engineer-knowledge-architecture#258で別追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/engineering-documentation-book/blob/main/README.md",
@@ -409,7 +422,19 @@
         "https://github.com/itdojp/engineering-documentation-book/blob/main/docs/appendices/glossary/index.md",
         "docs/professional-foundations.md",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/193",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/198"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/198",
+        "https://github.com/itdojp/engineering-documentation-book/blob/3df782481f883764ffc4f6eff0439ee0bcaded7e/book-config.json",
+        "https://github.com/itdojp/engineering-documentation-book/blob/3df782481f883764ffc4f6eff0439ee0bcaded7e/docs/appendices/figure-index/index.md",
+        "https://github.com/itdojp/engineering-documentation-book/blob/3df782481f883764ffc4f6eff0439ee0bcaded7e/docs/chapters/chapter-05/index.md",
+        "https://github.com/itdojp/engineering-documentation-book/blob/3df782481f883764ffc4f6eff0439ee0bcaded7e/docs/appendices/templates/architecture-diagram/index.md",
+        "https://github.com/itdojp/engineering-documentation-book/blob/3df782481f883764ffc4f6eff0439ee0bcaded7e/scripts/check-reader-ux.js",
+        "https://github.com/itdojp/engineering-documentation-book/issues/32",
+        "https://github.com/itdojp/engineering-documentation-book/pull/33",
+        "https://itdojp.github.io/engineering-documentation-book/appendices/figure-index/",
+        "https://github.com/itdojp/engineering-documentation-book/issues/32#issuecomment-4961041759",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250#issuecomment-4961044702",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258"
       ]
     },
     {
@@ -458,8 +483,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
-      "reviewIssue": 205,
+      "lastReviewedAt": "2026-07-14",
+      "reviewIssue": 250,
       "ux": {
         "profile": "B",
         "modules": {
@@ -468,15 +493,16 @@
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": false,
+          "figureIndex": true,
           "legalNotice": false,
           "glossary": true
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-12",
+      "updatedAt": "2026-07-14",
       "notes": [
-        "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がないためfigureIndex=falseとし、必須module debtの実装は#250で追跡する。"
+        "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がない状態を確認してfigureIndex=falseとし、必須module debtを#250へ追跡移管した。",
+        "2026-07-14にitdojp/it-engineer-knowledge-architecture#250、source Issue itdojp/security-privacy-literacy-book#37、source PR itdojp/security-privacy-literacy-book#38で、本文根拠を持つ安全なaccessible/self-contained SVG exact 4件、文章代替、stable anchorsと相対deep linksを持つ専用/appendices/figure-index/、top/navigation/prev-next、外部SVG/CSS resourceと秘密情報様文字列を拒否するfail-closed/compatibility回帰gateを実装。source main aa84ee0bc8f97d51070450925e67ed465adc69b7、review completeness unresolved 0、Book QA、CI、Pages、4 entries/anchors/assetsと公開導線の本番疎通を確認し、figureIndex=trueへ更新した。GitHub Actions Node.js 20廃止annotationはitdojp/it-engineer-knowledge-architecture#258で別追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/README.md",
@@ -488,7 +514,19 @@
         "https://github.com/itdojp/security-privacy-literacy-book/blob/4966d45234c336a71136bee7d79c8eb36140777f/docs/appendices/templates/index.md",
         "docs/professional-foundations.md",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/205",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/206"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/206",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/aa84ee0bc8f97d51070450925e67ed465adc69b7/book-config.json",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/aa84ee0bc8f97d51070450925e67ed465adc69b7/docs/appendices/figure-index/index.md",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/aa84ee0bc8f97d51070450925e67ed465adc69b7/docs/chapters/chapter-03/index.md",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/aa84ee0bc8f97d51070450925e67ed465adc69b7/docs/assets/images/figures/ch03-secret-handling.svg",
+        "https://github.com/itdojp/security-privacy-literacy-book/blob/aa84ee0bc8f97d51070450925e67ed465adc69b7/scripts/check-reader-ux.js",
+        "https://github.com/itdojp/security-privacy-literacy-book/issues/37",
+        "https://github.com/itdojp/security-privacy-literacy-book/pull/38",
+        "https://itdojp.github.io/security-privacy-literacy-book/appendices/figure-index/",
+        "https://github.com/itdojp/security-privacy-literacy-book/issues/37#issuecomment-4961041802",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250#issuecomment-4961044901",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258"
       ]
     },
     {
@@ -539,8 +577,8 @@
       ],
       "relatedEditions": [],
       "reviewStatus": "reviewed",
-      "lastReviewedAt": "2026-07-12",
-      "reviewIssue": 205,
+      "lastReviewedAt": "2026-07-14",
+      "reviewIssue": 250,
       "ux": {
         "profile": "B",
         "modules": {
@@ -549,15 +587,16 @@
           "checklistPack": true,
           "troubleshootingFlow": true,
           "conceptMap": false,
-          "figureIndex": false,
+          "figureIndex": true,
           "legalNotice": false,
           "glossary": false
         }
       },
       "addedAt": null,
-      "updatedAt": "2026-07-12",
+      "updatedAt": "2026-07-14",
       "notes": [
-        "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がないためfigureIndex=falseとし、必須module debtの実装は#250で追跡する。"
+        "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がない状態を確認してfigureIndex=falseとし、必須module debtを#250へ追跡移管した。",
+        "2026-07-14にitdojp/it-engineer-knowledge-architecture#250、source Issue itdojp/incident-response-basics-book#36、source PR itdojp/incident-response-basics-book#37で、初動、Severity/役割/タイムライン、連絡/エスカレーション、復旧/ポストモーテムを扱うaccessible/self-contained SVG exact 4件、文章代替、stable anchorsと章順deep linksを持つ専用/appendices/figure-index/、top/navigation/prev-nextとfail-closed/compatibility回帰gateを実装。source main 70d86403b604c3c5d374b6a4ef8f8288244d3ba1、review completeness unresolved 0、CI、Pages、4 entries/anchors/assetsと公開導線の本番疎通を確認し、figureIndex=trueへ更新した。GitHub Actions Node.js 20廃止annotationはitdojp/it-engineer-knowledge-architecture#258で別追跡する。"
       ],
       "sourceRefs": [
         "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/README.md",
@@ -569,7 +608,19 @@
         "https://github.com/itdojp/incident-response-basics-book/blob/42876458d1319e7323733468e7fc130a14a4afb7/docs/appendices/templates/index.md",
         "docs/professional-foundations.md",
         "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/205",
-        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/206"
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/pull/206",
+        "https://github.com/itdojp/incident-response-basics-book/blob/70d86403b604c3c5d374b6a4ef8f8288244d3ba1/book-config.json",
+        "https://github.com/itdojp/incident-response-basics-book/blob/70d86403b604c3c5d374b6a4ef8f8288244d3ba1/docs/appendices/figure-index/index.md",
+        "https://github.com/itdojp/incident-response-basics-book/blob/70d86403b604c3c5d374b6a4ef8f8288244d3ba1/docs/chapters/chapter-05/index.md",
+        "https://github.com/itdojp/incident-response-basics-book/blob/70d86403b604c3c5d374b6a4ef8f8288244d3ba1/docs/assets/images/figures/ch05-severity-roles-timeline.svg",
+        "https://github.com/itdojp/incident-response-basics-book/blob/70d86403b604c3c5d374b6a4ef8f8288244d3ba1/scripts/check-reader-ux.js",
+        "https://github.com/itdojp/incident-response-basics-book/issues/36",
+        "https://github.com/itdojp/incident-response-basics-book/pull/37",
+        "https://itdojp.github.io/incident-response-basics-book/appendices/figure-index/",
+        "https://github.com/itdojp/incident-response-basics-book/issues/36#issuecomment-4961041797",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/250#issuecomment-4961045138",
+        "https://github.com/itdojp/it-engineer-knowledge-architecture/issues/258"
       ]
     },
     {

--- a/docs/publishing/book-registry.json
+++ b/docs/publishing/book-registry.json
@@ -189,11 +189,11 @@
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": false,
+        "figureIndex": true,
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引は未実装。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
+      "notes": "2026-07-12のmetadata監査#193で、UX設定がbook-configにないことを確認し、実務参照を主目的とするProfile B、公開トップの読み方ガイド、Runbookテンプレート、チェックリスト、用語集の実体からmodulesを判定。独立した図表索引がない状態を確認し、必須module debtを#250へ追跡移管した。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。 / 2026-07-14にitdojp/it-engineer-knowledge-architecture#250、source Issue itdojp/engineering-documentation-book#32、source PR itdojp/engineering-documentation-book#33で、公開Mermaid正本exact 5件に対応するaccessible/self-contained SVG preview、stable anchorsと相対deep linksを持つ専用/appendices/figure-index/、top/navigation/prev-nextとfail-closed/compatibility回帰gateを実装。source main 3df782481f883764ffc4f6eff0439ee0bcaded7e、review completeness unresolved 0、CI、Pages、5 entries/anchors/assetsと公開導線の本番疎通を確認し、figureIndex=trueへ更新した。GitHub Actions Node.js 20廃止annotationはitdojp/it-engineer-knowledge-architecture#258で別追跡する。"
     },
     "ethereum-learning-bootcamp": {
       "repo": "itdojp/ethereum-learning-bootcamp",
@@ -317,11 +317,11 @@
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": false,
+        "figureIndex": true,
         "legalNotice": false,
         "glossary": false
       },
-      "notes": "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がないためfigureIndex=falseとし、必須module debtの実装は#250で追跡する。"
+      "notes": "2026-07-12のmetadata監査#205で、source main 42876458d1319e7323733468e7fc130a14a4afb7の公開トップ、章1〜8、チェックリスト、テンプレートを照合し、実務適用型のProfile Bとmodulesを確定。期間は根拠がなく、専用図表索引がない状態を確認してfigureIndex=falseとし、必須module debtを#250へ追跡移管した。 / 2026-07-14にitdojp/it-engineer-knowledge-architecture#250、source Issue itdojp/incident-response-basics-book#36、source PR itdojp/incident-response-basics-book#37で、初動、Severity/役割/タイムライン、連絡/エスカレーション、復旧/ポストモーテムを扱うaccessible/self-contained SVG exact 4件、文章代替、stable anchorsと章順deep linksを持つ専用/appendices/figure-index/、top/navigation/prev-nextとfail-closed/compatibility回帰gateを実装。source main 70d86403b604c3c5d374b6a4ef8f8288244d3ba1、review completeness unresolved 0、CI、Pages、4 entries/anchors/assetsと公開導線の本番疎通を確認し、figureIndex=trueへ更新した。GitHub Actions Node.js 20廃止annotationはitdojp/it-engineer-knowledge-architecture#258で別追跡する。"
     },
     "issue-driven-work-book": {
       "repo": "itdojp/issue-driven-work-book",
@@ -335,9 +335,9 @@
         "conceptMap": false,
         "figureIndex": false,
         "legalNotice": true,
-        "glossary": false
+        "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。"
+      "notes": "2026-07-12のmetadata監査#193で、book-configのProfile Aとmodulesを、公開トップのクイックスタート・注意事項・読み方ガイド、トリアージ判断表、チェックリスト、LICENSEの実体と照合済み。PR #198のmerge後にmain validation、Deploy Pages、production smoke、Pages drift、公開49カードと当該概要を確認し、品質スプリント#193のレビュー証跡を確定。 / 2026-07-14にitdojp/it-engineer-knowledge-architecture#250、source Issue itdojp/issue-driven-work-book#34、source PR itdojp/issue-driven-work-book#35で、本文根拠とcanonical参照を持つexact 18用語の専用/appendices/glossary/、stable anchors/deep links、top/navigation/prev-nextとfail-closed回帰gateを実装。source main ff236e117f8570470c0b44b1e2a4954104629e6a、review completeness unresolved 0、CI、Pages、18 anchors/referencesと公開導線の本番疎通を確認し、glossary=trueへ更新した。GitHub Actions Node.js 20廃止annotationはitdojp/it-engineer-knowledge-architecture#258で別追跡する。"
     },
     "IT-engineer-communication-book": {
       "repo": "itdojp/IT-engineer-communication-book",
@@ -589,11 +589,11 @@
         "checklistPack": true,
         "troubleshootingFlow": true,
         "conceptMap": false,
-        "figureIndex": false,
+        "figureIndex": true,
         "legalNotice": false,
         "glossary": true
       },
-      "notes": "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がないためfigureIndex=falseとし、必須module debtの実装は#250で追跡する。"
+      "notes": "2026-07-12のmetadata監査#205で、source main 4966d45234c336a71136bee7d79c8eb36140777fのbook-configと公開トップ、チェックリスト、テンプレートを照合し、Profile Bとmodulesを確定。時間目安は週換算せず、専用図表索引がない状態を確認してfigureIndex=falseとし、必須module debtを#250へ追跡移管した。 / 2026-07-14にitdojp/it-engineer-knowledge-architecture#250、source Issue itdojp/security-privacy-literacy-book#37、source PR itdojp/security-privacy-literacy-book#38で、本文根拠を持つ安全なaccessible/self-contained SVG exact 4件、文章代替、stable anchorsと相対deep linksを持つ専用/appendices/figure-index/、top/navigation/prev-next、外部SVG/CSS resourceと秘密情報様文字列を拒否するfail-closed/compatibility回帰gateを実装。source main aa84ee0bc8f97d51070450925e67ed465adc69b7、review completeness unresolved 0、Book QA、CI、Pages、4 entries/anchors/assetsと公開導線の本番疎通を確認し、figureIndex=trueへ更新した。GitHub Actions Node.js 20廃止annotationはitdojp/it-engineer-knowledge-architecture#258で別追跡する。"
     },
     "small-webapp-software-design-book": {
       "repo": "itdojp/small-webapp-software-design-book",

--- a/docs/publishing/catalog-debt-report.json
+++ b/docs/publishing/catalog-debt-report.json
@@ -138,8 +138,8 @@
       "bookIds": []
     },
     "missingRequiredUxModules": {
-      "count": 10,
-      "bookCount": 7,
+      "count": 6,
+      "bookCount": 3,
       "books": [
         {
           "id": "ai-agent-collaboration-book",
@@ -194,54 +194,6 @@
               "trackingIssue": 230
             }
           ]
-        },
-        {
-          "id": "engineering-documentation-book",
-          "profile": "B",
-          "missingModules": [
-            {
-              "module": "figureIndex",
-              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-              "evidenceIssue": 193,
-              "trackingIssue": 250
-            }
-          ]
-        },
-        {
-          "id": "incident-response-basics-book",
-          "profile": "B",
-          "missingModules": [
-            {
-              "module": "figureIndex",
-              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-              "evidenceIssue": 205,
-              "trackingIssue": 250
-            }
-          ]
-        },
-        {
-          "id": "issue-driven-work-book",
-          "profile": "A",
-          "missingModules": [
-            {
-              "module": "glossary",
-              "reason": "実ファイル監査で専用の用語導線が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-              "evidenceIssue": 193,
-              "trackingIssue": 250
-            }
-          ]
-        },
-        {
-          "id": "security-privacy-literacy-book",
-          "profile": "B",
-          "missingModules": [
-            {
-              "module": "figureIndex",
-              "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-              "evidenceIssue": 205,
-              "trackingIssue": 250
-            }
-          ]
         }
       ]
     },
@@ -252,8 +204,8 @@
   },
   "gates": {
     "requiredUxModuleDebt": {
-      "baselineCount": 10,
-      "currentCount": 10,
+      "baselineCount": 6,
+      "currentCount": 6,
       "unapprovedCount": 0,
       "unapproved": [],
       "staleBaselineCount": 0,

--- a/docs/publishing/ux-required-module-debt-baseline.json
+++ b/docs/publishing/ux-required-module-debt-baseline.json
@@ -2,38 +2,6 @@
   "schemaVersion": "1.0.0",
   "entries": [
     {
-      "bookId": "engineering-documentation-book",
-      "profile": "B",
-      "module": "figureIndex",
-      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-      "evidenceIssue": 193,
-      "trackingIssue": 250
-    },
-    {
-      "bookId": "incident-response-basics-book",
-      "profile": "B",
-      "module": "figureIndex",
-      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-      "evidenceIssue": 205,
-      "trackingIssue": 250
-    },
-    {
-      "bookId": "issue-driven-work-book",
-      "profile": "A",
-      "module": "glossary",
-      "reason": "実ファイル監査で専用の用語導線が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-      "evidenceIssue": 193,
-      "trackingIssue": 250
-    },
-    {
-      "bookId": "security-privacy-literacy-book",
-      "profile": "B",
-      "module": "figureIndex",
-      "reason": "実ファイル監査で専用の図表索引が未実装であることを確認済み。根拠のないtrueへの変更は行わない。",
-      "evidenceIssue": 205,
-      "trackingIssue": 250
-    },
-    {
       "bookId": "ai-agent-collaboration-book",
       "profile": "B",
       "module": "troubleshootingFlow",


### PR DESCRIPTION
## 概要

Closes #250

Process・Documentation・Security 4冊でsource実装・レビュー・main CI・Pages本番確認が完了した必須Reader UX module exact 4件をcatalogへ反映し、対応baselineだけを削除します。

## Source evidence

- issue-driven-work-book #34 / PR #35 / main `ff236e117f8570470c0b44b1e2a4954104629e6a`
  - 本文根拠とcanonical参照を持つexact 18用語の`/appendices/glossary/`、stable anchors/deep links、top/sidebar/prev-next
- engineering-documentation-book #32 / PR #33 / main `3df782481f883764ffc4f6eff0439ee0bcaded7e`
  - 公開Mermaid正本exact 5件に対応するaccessible/self-contained SVG previewと`/appendices/figure-index/`
- security-privacy-literacy-book #37 / PR #38 / main `aa84ee0bc8f97d51070450925e67ed465adc69b7`
  - 本文根拠を持つ安全なaccessible/self-contained SVG exact 4件と`/appendices/figure-index/`
- incident-response-basics-book #36 / PR #37 / main `70d86403b604c3c5d374b6a4ef8f8288244d3ba1`
  - 章順の対応フローSVG exact 4件と`/appendices/figure-index/`

各sourceでCopilot/Codexレビュー全文・inline・suggestion、unresolved thread 0、PR/main CI、Pages、本番route/deep linksを確認済みです。Actions Node.js 20廃止annotationは#258へ分離したままです。

## Catalog変更

- module false→true exact 4件
  - issue-driven-work-book: glossary
  - engineering-documentation-book: figureIndex
  - security-privacy-literacy-book: figureIndex
  - incident-response-basics-book: figureIndex
- `lastReviewedAt` / `reviewIssue` / `updatedAt` と履歴note/sourceRefsを固定main証跡へ更新
- baselineから `trackingIssue=250` のexact 4件だけを削除
- registry/debt reportを再生成
- #230で追跡中の6件は変更せず維持

## 検証

- `npm ci`
- `npm audit --audit-level=moderate`（0 vulnerabilities）
- 対象4冊のsourceRefs 84 URL（うち新規47 URL）をGitHub API/HTTPで検証し全件成功
- `npm run generate`
- `node scripts/validate-ux-registry.js`（41 books）
- `npm run verify`
  - catalog 49 records / paths 7
  - required UX debt baseline/current 6/6
  - unapproved/stale 0/0、reader leak 0
  - catalog debt 11/11、completion 6/6、smoke 8/8、drift 7/7、Playwright 45/45
- `git diff --check`
